### PR TITLE
DEP-35 config: firebase app distribution 추가

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-@depromeet12th/android
+*       @depromeet12th/android

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,3 +34,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: chmod +x ./gradlew && ./gradlew build sonarqube --info
+      - name: Firebase App Distribution
+          uses: wzieba/Firebase-Distribution-Github-Action@v1.3.5
+          with:
+            appId: ${{secrets.FIREBASE_APP_ID}}
+            token: ${{secrets.FIREBASE_TOKEN}}
+            groups: depromeet-12th-8th
+            file: app/build/outputs/apk/debug/app-debug.apk

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,9 +35,9 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: chmod +x ./gradlew && ./gradlew build sonarqube --info
       - name: Firebase App Distribution
-          uses: wzieba/Firebase-Distribution-Github-Action@v1.3.5
-          with:
-            appId: ${{secrets.FIREBASE_APP_ID}}
-            token: ${{secrets.FIREBASE_TOKEN}}
-            groups: depromeet-12th-8th
-            file: app/build/outputs/apk/debug/app-debug.apk
+        uses: wzieba/Firebase-Distribution-Github-Action@v1.3.5
+        with:
+          appId: ${{secrets.FIREBASE_APP_ID}}
+          token: ${{secrets.FIREBASE_TOKEN}}
+          groups: depromeet-12th-8th
+          file: app/build/outputs/apk/debug/app-debug.apk

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,8 +3,6 @@ on:
   push:
     branches:
       - develop
-  pull_request:
-    types: [opened, synchronize, reopened]
 jobs:
   build:
     name: Build
@@ -29,8 +27,10 @@ jobs:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
           restore-keys: ${{ runner.os }}-gradle
-      - name: Build and analyze
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: chmod +x ./gradlew && ./gradlew build sonarqube --info
+      - name: Firebase App Distribution
+        uses: wzieba/Firebase-Distribution-Github-Action@v1.3.5
+        with:
+          appId: ${{secrets.FIREBASE_APP_ID}}
+          token: ${{secrets.FIREBASE_TOKEN}}
+          groups: depromeet-12th-8th
+          file: app/build/outputs/apk/debug/app-debug.apk


### PR DESCRIPTION
- firebase app distribution 단계 추가했습니다. 
- 매 PR 변경마다 앱을 배포하는건 낭비인거같아서 develop 코드 변경될때만 배포하도록 설정했습니다
- 공용구글계정 firebase console 에서 확인하실수있어요