### PR TITLE
DEP-48 ui: 홈화면(목표 목록 페이지) 그리기

### DIFF
--- a/core-design-system/src/main/res/drawable/bg_rect_gray_r10.xml
+++ b/core-design-system/src/main/res/drawable/bg_rect_gray_r10.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- plus button에 사용되는 회색 둥근 모서리 네모 -->
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+
+    <solid android:color="#D4D4D4" />
+    <corners android:radius="10dp" />
+
+</shape>

--- a/presentation/home/src/main/java/com/depromeet/threedays/home/home/HomeFragment.kt
+++ b/presentation/home/src/main/java/com/depromeet/threedays/home/home/HomeFragment.kt
@@ -1,0 +1,7 @@
+package com.depromeet.threedays.home.home
+
+import androidx.fragment.app.Fragment
+
+class HomeFragment : Fragment() {
+
+}

--- a/presentation/home/src/main/res/drawable/bg_oval_gray.xml
+++ b/presentation/home/src/main/res/drawable/bg_oval_gray.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+
+    <solid android:color="#DCE5EE" />
+
+</shape>

--- a/presentation/home/src/main/res/drawable/bg_oval_white.xml
+++ b/presentation/home/src/main/res/drawable/bg_oval_white.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+
+    <solid android:color="@color/white" />
+
+</shape>

--- a/presentation/home/src/main/res/drawable/bg_oval_white_stroke_blue.xml
+++ b/presentation/home/src/main/res/drawable/bg_oval_white_stroke_blue.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="oval">
+    <solid android:color="@color/white"/>
+    <stroke android:width="3dp" android:color="#3F80FF"/>
+</shape>

--- a/presentation/home/src/main/res/drawable/bg_rect_blue_r5.xml
+++ b/presentation/home/src/main/res/drawable/bg_rect_blue_r5.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+
+    <solid android:color="#D3E5FF" />
+    <corners android:radius="5dp" />
+
+</shape>

--- a/presentation/home/src/main/res/drawable/bg_rect_light_blue_r24.xml
+++ b/presentation/home/src/main/res/drawable/bg_rect_light_blue_r24.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+
+    <solid android:color="#EDF6FF" />
+    <corners android:radius="24dp" />
+
+</shape>

--- a/presentation/home/src/main/res/layout/fragment_home.xml
+++ b/presentation/home/src/main/res/layout/fragment_home.xml
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:padding="20dp"
+        android:background="@color/white"
+        tools:context=".home.HomeFragment">
+
+        <TextView
+            android:id="@+id/tv_date"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:fontFamily="@font/suit_bold"
+            android:text="10. 13 (목)"
+            android:textColor="#8F8F8F"
+            android:textSize="14sp"
+            android:layout_marginTop="53dp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/tv_header"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="14dp"
+            android:fontFamily="@font/suit_bold"
+            android:text="작심삼일에서\n작심삼백일까지 함께해요"
+            android:textColor="#1A1F27"
+            android:textSize="22sp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/tv_date" />
+
+        <!-- 등록된 목표가 있는 경우에 보여지는 버튼 -->
+        <ImageView
+            android:layout_width="44dp"
+            android:layout_height="44dp"
+            android:layout_gravity="center"
+            android:background="@drawable/bg_rect_gray_r10"
+            android:padding="10dp"
+            android:backgroundTint="#F0F0F0"
+            android:visibility="gone"
+            app:layout_constraintBottom_toBottomOf="@+id/tv_header"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="@+id/tv_header"
+            app:srcCompat="@drawable/ic_plus" />
+
+        <!-- 등록된 목표가 없는 경우에 보여지는 레이아웃 -->
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="32dp"
+            app:layout_constraintTop_toBottomOf="@+id/tv_header">
+
+            <androidx.cardview.widget.CardView
+                android:layout_width="match_parent"
+                android:layout_height="220dp"
+                android:backgroundTint="#F9FAFB"
+                app:cardCornerRadius="16dp"
+                app:cardElevation="0dp"
+                app:layout_constraintTop_toTopOf="parent">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical">
+
+                    <ImageView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center"
+                        android:layout_marginTop="20dp"
+                        app:srcCompat="@drawable/img_hand_01" />
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="10dp"
+                        android:fontFamily="@font/suit_bold"
+                        android:text="짝심삼일 시작해볼래요?"
+                        android:textColor="#1A1F27"
+                        android:textSize="17sp"
+                        android:layout_gravity="center" />
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:fontFamily="@font/suit_medium"
+                        android:text="3일을 채울 때 마다 짝! 박수를 쳐드려요"
+                        android:textColor="#757575"
+                        android:textSize="15sp"
+                        android:layout_marginTop="5dp"
+                        android:layout_gravity="center" />
+
+                    <androidx.appcompat.widget.AppCompatButton
+                        android:id="@+id/btn_make_goal"
+                        android:layout_width="100dp"
+                        android:layout_height="35dp"
+                        android:fontFamily="@font/suit_bold"
+                        android:textSize="14sp"
+                        android:text="목표 만들기"
+                        android:textColor="@color/white"
+                        android:layout_gravity="center"
+                        android:gravity="center"
+                        android:layout_marginTop="20dp"
+                        android:background="@drawable/bg_rect_primary_r10" />
+                </LinearLayout>
+            </androidx.cardview.widget.CardView>
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/presentation/home/src/main/res/layout/item_goal.xml
+++ b/presentation/home/src/main/res/layout/item_goal.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:tools="http://schemas.android.com/tools"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <data>
+
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingBottom="13dp"
+        android:background="@drawable/bg_rect_light_blue_r24">
+
+        <TextView
+            android:id="@+id/tv_day"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:layout_marginTop="12dp"
+            android:background="@drawable/bg_rect_blue_r5"
+            android:fontFamily="@font/suit_bold"
+            android:paddingHorizontal="12.5dp"
+            android:paddingVertical="5dp"
+            android:text="짝심 5일"
+            android:textColor="#3F80FF"
+            android:textSize="13sp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/tv_goal"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:layout_marginTop="8dp"
+            android:fontFamily="@font/suit_bold"
+            android:text="안녕하세요안녕하세요안녕하세요"
+            android:textColor="#1A1F27"
+            android:textSize="18sp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/tv_day" />
+
+        <ImageView
+            android:id="@+id/iv_first_day"
+            android:layout_width="84dp"
+            android:layout_height="84dp"
+            android:layout_gravity="center"
+            android:background="@drawable/bg_oval_white"
+            android:layout_marginTop="19dp"
+            app:layout_constraintEnd_toStartOf="@+id/iv_second_day"
+            app:layout_constraintHorizontal_bias="0.5"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/tv_goal"
+            app:srcCompat="@drawable/ic_hand_done" />
+
+        <ImageView
+            android:id="@+id/iv_second_day"
+            android:layout_width="84dp"
+            android:layout_height="84dp"
+            android:layout_gravity="center"
+            android:background="@drawable/bg_oval_white_stroke_blue"
+            app:layout_constraintBottom_toBottomOf="@+id/iv_first_day"
+            app:layout_constraintEnd_toStartOf="@+id/iv_third_day"
+            app:layout_constraintHorizontal_bias="0.5"
+            app:layout_constraintStart_toEndOf="@+id/iv_first_day"
+            app:srcCompat="@drawable/ic_hand_done" />
+
+        <ImageView
+            android:id="@+id/iv_third_day"
+            android:layout_width="84dp"
+            android:layout_height="84dp"
+            android:layout_gravity="center"
+            android:background="@drawable/bg_oval_gray"
+            app:layout_constraintBottom_toBottomOf="@+id/iv_second_day"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.5"
+            app:layout_constraintStart_toEndOf="@+id/iv_second_day"
+            app:srcCompat="@drawable/ic_hand_normal" />
+
+        <ImageView
+            android:id="@+id/iv_more"
+            android:layout_width="24dp"
+            android:layout_height="24dp"
+            android:layout_gravity="center"
+            android:layout_marginTop="14dp"
+            android:layout_marginEnd="16dp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:srcCompat="@drawable/ic_more" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>


### PR DESCRIPTION
## 💁‍♂️ PR 내용

![20221015_013105](https://user-images.githubusercontent.com/76620764/195910593-7bf0d238-a084-479e-89c1-34cc404639f3.png)
![20221015_021215](https://user-images.githubusercontent.com/76620764/195910597-62b99852-817d-4885-a0f2-d7d6e775c86f.png)

목표 목록 페이지에 해당하는 ui를
뚝딱뚝딱 만들어 봤습니다.

## 📢 전달사항

폰트나 색상 이런 부분에 있어서 굉장히 러프하게 짰어요.
피그마에 있는 UT 가이드가 아직 체계가 안 잡혀있는 부분이 많아서
뭐 폰트를 typography나 theme로 묶는다든지
색상마다 이름이 있어서 네이밍에 적용한다든지 이런 게 불가능 하더라구요.
나중에 수정 해야 할 것 같습니다 흑 