### PR TITLE
DEP-35 config: tester 그룹 변경

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,6 +37,6 @@ jobs:
           appId: ${{secrets.FIREBASE_APP_ID}}
           token: ${{secrets.FIREBASE_TOKEN}}
           serviceCredentialsFile: credential_file.json
-          groups: depromeet-12th-8th, depromeet, android
+          groups: android
           file: app/build/outputs/apk/debug/app-debug.apk
           debug: true


### PR DESCRIPTION
## AS-IS
- develop 코드가 변경되면 depromeet, 12기8팀 그룹 등 iOS, android 로 구분되지 않은 채 모든 테스터가 알림 메일을 받습니다. 

## TO-BE 

- develop 코드 변경시, android 테스터 그룹에만 새 앱 업로드 알림 메일이 가도록 변경합니다. 