### PR TITLE
DEP-71 feat: 목표 수정 페이지 생성 및 기능 구현

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -26,7 +26,7 @@
         </activity>
 
         <activity
-            android:name="com.depromeet.threedays.register.GoalAddActivity"
+            android:name="com.depromeet.threedays.register.add.GoalAddActivity"
             android:exported="false"/>
     </application>
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -28,6 +28,10 @@
         <activity
             android:name="com.depromeet.threedays.register.add.GoalAddActivity"
             android:exported="false"/>
+
+        <activity
+            android:name="com.depromeet.threedays.register.update.GoalUpdateActivity"
+            android:exported="false"/>
     </application>
 
 </manifest>

--- a/data/src/main/java/com/depromeet/threedays/data/mapper/GoalMapper.kt
+++ b/data/src/main/java/com/depromeet/threedays/data/mapper/GoalMapper.kt
@@ -2,6 +2,8 @@ package com.depromeet.threedays.data.mapper
 
 import com.depromeet.threedays.data.entity.GoalEntity
 import com.depromeet.threedays.domain.entity.Goal
+import java.time.ZoneId
+import java.time.ZonedDateTime
 
 fun Goal.toGoalEntity(): GoalEntity {
     return GoalEntity(
@@ -13,13 +15,9 @@ fun Goal.toGoalEntity(): GoalEntity {
 fun GoalEntity.toGoal() = Goal(
     goalId = this.goalId,
     title = this.title,
-    startDate = "",
-    endDate = "",
-    startTime = "",
-    notificationTime = "",
+    startDate = ZonedDateTime.now(ZoneId.systemDefault()),
+    endDate = ZonedDateTime.now(ZoneId.systemDefault()),
+    startTime = ZonedDateTime.now(ZoneId.systemDefault()),
+    notificationTime = ZonedDateTime.now(ZoneId.systemDefault()),
     notificationContent = "",
-    status = "",
-    createDate = "",
-    sequence = "",
-    lastAchievementDate = "",
 )

--- a/domain/src/main/java/com/depromeet/threedays/domain/entity/Goal.kt
+++ b/domain/src/main/java/com/depromeet/threedays/domain/entity/Goal.kt
@@ -1,15 +1,13 @@
 package com.depromeet.threedays.domain.entity
 
+import java.time.ZonedDateTime
+
 data class Goal(
     val goalId: Long,
     val title: String,
-    val startDate: String,
-    val endDate: String,
-    val startTime: String,
-    val notificationTime: String,
-    val notificationContent: String,
-    val status: String,
-    val createDate: String,
-    val sequence: String,
-    val lastAchievementDate: String
+    val startDate: ZonedDateTime?,
+    val endDate: ZonedDateTime?,
+    val startTime: ZonedDateTime?,
+    val notificationTime: ZonedDateTime?,
+    val notificationContent: String?
 )

--- a/presentation/register/src/main/java/com/depromeet/threedays/register/SimpleGoal.kt
+++ b/presentation/register/src/main/java/com/depromeet/threedays/register/SimpleGoal.kt
@@ -1,0 +1,38 @@
+package com.depromeet.threedays.register
+
+import com.depromeet.threedays.domain.entity.Goal
+import kotlinx.coroutines.flow.MutableStateFlow
+import java.time.ZoneId
+import java.time.ZonedDateTime
+
+data class SimpleGoal(
+    val goalId: Long,
+    val title: MutableStateFlow<String>,
+    var startDate: ZonedDateTime,
+    var endDate: ZonedDateTime,
+    var startTime: ZonedDateTime,
+    var notificationTime: ZonedDateTime,
+    var notificationContent: String
+) {
+    companion object {
+        val EMPTY = SimpleGoal(
+            goalId = 0,
+            title = MutableStateFlow(""),
+            startDate = ZonedDateTime.now(ZoneId.systemDefault()),
+            endDate = ZonedDateTime.now(ZoneId.systemDefault()),
+            startTime = ZonedDateTime.now(ZoneId.systemDefault()),
+            notificationTime = ZonedDateTime.now(ZoneId.systemDefault()),
+            notificationContent = ""
+        )
+    }
+}
+
+fun Goal.toSimpleGoal() = SimpleGoal(
+    goalId = this.goalId,
+    title = MutableStateFlow(this.title),
+    startDate = ZonedDateTime.now(ZoneId.systemDefault()),
+    endDate = ZonedDateTime.now(ZoneId.systemDefault()),
+    startTime = ZonedDateTime.now(ZoneId.systemDefault()),
+    notificationTime = ZonedDateTime.now(ZoneId.systemDefault()),
+    notificationContent = "",
+)

--- a/presentation/register/src/main/java/com/depromeet/threedays/register/add/GoalAddActivity.kt
+++ b/presentation/register/src/main/java/com/depromeet/threedays/register/add/GoalAddActivity.kt
@@ -1,4 +1,4 @@
-package com.depromeet.threedays.register
+package com.depromeet.threedays.register.add
 
 import android.app.DatePickerDialog
 import android.app.TimePickerDialog
@@ -12,7 +12,8 @@ import androidx.activity.viewModels
 import androidx.core.widget.addTextChangedListener
 import androidx.lifecycle.lifecycleScope
 import com.depromeet.threedays.core.BaseActivity
-import com.depromeet.threedays.register.GoalAddViewModel.Action.*
+import com.depromeet.threedays.register.R
+import com.depromeet.threedays.register.add.GoalAddViewModel.Action.*
 import com.depromeet.threedays.register.databinding.ActivityGoalAddBinding
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.launchIn

--- a/presentation/register/src/main/java/com/depromeet/threedays/register/add/GoalAddViewModel.kt
+++ b/presentation/register/src/main/java/com/depromeet/threedays/register/add/GoalAddViewModel.kt
@@ -1,4 +1,4 @@
-package com.depromeet.threedays.register
+package com.depromeet.threedays.register.add
 
 import androidx.lifecycle.viewModelScope
 import com.depromeet.threedays.core.BaseViewModel

--- a/presentation/register/src/main/java/com/depromeet/threedays/register/update/GoalUpdateActivity.kt
+++ b/presentation/register/src/main/java/com/depromeet/threedays/register/update/GoalUpdateActivity.kt
@@ -13,8 +13,8 @@ import androidx.core.widget.addTextChangedListener
 import androidx.lifecycle.lifecycleScope
 import com.depromeet.threedays.core.BaseActivity
 import com.depromeet.threedays.register.R
-import com.depromeet.threedays.register.update.GoalUpdateViewModel.Action.*
 import com.depromeet.threedays.register.databinding.ActivityGoalUpdateBinding
+import com.depromeet.threedays.register.update.GoalUpdateViewModel.Action.*
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -27,6 +27,7 @@ class GoalUpdateActivity : BaseActivity<ActivityGoalUpdateBinding>(R.layout.acti
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding.viewModel = viewModel
+        getData()
         initView()
         observe()
     }
@@ -46,6 +47,12 @@ class GoalUpdateActivity : BaseActivity<ActivityGoalUpdateBinding>(R.layout.acti
             }
         }
         return super.dispatchTouchEvent(event)
+    }
+
+    private fun getData() {
+        // 홈에서 넘겨받은 id값으로 goal 데이터 불러오기
+        // val id = intent.getLongExtra("goalId", 1)
+        // viewModel.getGoalById(id)
     }
 
     private fun initView() {
@@ -72,10 +79,11 @@ class GoalUpdateActivity : BaseActivity<ActivityGoalUpdateBinding>(R.layout.acti
 
     private fun observe() {
         viewModel.action.onEach { action ->
-            when(action){
+            when (action) {
                 is StartCalendarClick -> showDatePicker(action.currentDate, true)
                 is EndCalendarClick -> showDatePicker(action.currentDate, false)
                 is RunTimeClick -> showTimePicker(action.currentTime)
+                is UpdateClick -> finish()
             }
         }.launchIn(lifecycleScope)
     }

--- a/presentation/register/src/main/java/com/depromeet/threedays/register/update/GoalUpdateActivity.kt
+++ b/presentation/register/src/main/java/com/depromeet/threedays/register/update/GoalUpdateActivity.kt
@@ -1,12 +1,135 @@
 package com.depromeet.threedays.register.update
 
-import androidx.appcompat.app.AppCompatActivity
+import android.app.DatePickerDialog
+import android.app.TimePickerDialog
+import android.graphics.Rect
 import android.os.Bundle
+import android.view.MotionEvent
+import android.view.View
+import android.view.inputmethod.InputMethodManager
+import android.widget.EditText
+import androidx.activity.viewModels
+import androidx.core.widget.addTextChangedListener
+import androidx.lifecycle.lifecycleScope
+import com.depromeet.threedays.core.BaseActivity
 import com.depromeet.threedays.register.R
+import com.depromeet.threedays.register.update.GoalUpdateViewModel.Action.*
+import com.depromeet.threedays.register.databinding.ActivityGoalUpdateBinding
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import java.time.ZonedDateTime
 
-class GoalUpdateActivity : AppCompatActivity() {
+@AndroidEntryPoint
+class GoalUpdateActivity : BaseActivity<ActivityGoalUpdateBinding>(R.layout.activity_goal_update) {
+    private val viewModel by viewModels<GoalUpdateViewModel>()
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_goal_update)
+        binding.viewModel = viewModel
+        initView()
+        observe()
+    }
+
+    override fun dispatchTouchEvent(event: MotionEvent): Boolean {
+        if (event.action == MotionEvent.ACTION_DOWN) {
+            val v = currentFocus
+            if (v is EditText) {
+                val outRect = Rect()
+                v.getGlobalVisibleRect(outRect)
+                if (!outRect.contains(event.rawX.toInt(), event.rawY.toInt())) {
+                    v.clearFocus()
+                    val imm: InputMethodManager =
+                        getSystemService(INPUT_METHOD_SERVICE) as InputMethodManager
+                    imm.hideSoftInputFromWindow(v.getWindowToken(), 0)
+                }
+            }
+        }
+        return super.dispatchTouchEvent(event)
+    }
+
+    private fun initView() {
+        binding.ivClose.setOnClickListener {
+            finish()
+        }
+
+        binding.etGoalName.addTextChangedListener {
+            binding.tvGoalCounter.text = String.format("%d/15", it?.length ?: 0)
+        }
+
+        binding.etNotificationContent.addTextChangedListener {
+            binding.tvNotificationCounter.text = String.format("%d/20", it?.length ?: 0)
+        }
+
+        binding.swGoalPeriod.setOnCheckedChangeListener { _, isChecked ->
+            binding.clPeriod.visibility = if (isChecked) View.VISIBLE else View.GONE
+        }
+
+        binding.swRunTime.setOnCheckedChangeListener { _, isChecked ->
+            binding.tvRunTime.visibility = if (isChecked) View.VISIBLE else View.GONE
+        }
+    }
+
+    private fun observe() {
+        viewModel.action.onEach { action ->
+            when(action){
+                is StartCalendarClick -> showDatePicker(action.currentDate, true)
+                is EndCalendarClick -> showDatePicker(action.currentDate, false)
+                is RunTimeClick -> showTimePicker(action.currentTime)
+            }
+        }.launchIn(lifecycleScope)
+    }
+
+    private fun showDatePicker(zonedDateTime: ZonedDateTime, isStart: Boolean) {
+        val dateSetListener = DatePickerDialog.OnDateSetListener { _, year, month, dayOfMonth ->
+            if (isStart) {
+                viewModel.setStartDate(year, month + 1, dayOfMonth)
+            } else {
+                viewModel.setEndDate(year, month + 1, dayOfMonth)
+            }
+        }
+
+        DatePickerDialog(
+            this,
+            dateSetListener,
+            zonedDateTime.year,
+            zonedDateTime.monthValue - 1,
+            zonedDateTime.dayOfMonth
+        ).show()
+    }
+
+    private fun showTimePicker(zonedDateTime: ZonedDateTime) {
+        val timeSetListener = TimePickerDialog.OnTimeSetListener { _, hour, min ->
+            viewModel.setStartTimeWithNotificationTime(hour, min)
+            binding.tvRunTime.text =
+                when (hour) {
+                    12 -> String.format(
+                        getString(R.string.three_days_time_afternoon_format),
+                        hour,
+                        min
+                    )
+                    in 13..23 -> String.format(
+                        getString(R.string.three_days_time_afternoon_format),
+                        hour - 12,
+                        min
+                    )
+                    24 -> String.format(getString(R.string.three_days_time_morning_format), 0, min)
+                    else -> String.format(
+                        getString(R.string.three_days_time_morning_format),
+                        hour,
+                        min
+                    )
+                }.also { binding.tvNotification.text = it }
+        }
+        val dialog = TimePickerDialog(
+            this,
+            android.R.style.Theme_Holo_Light_Dialog_NoActionBar,
+            timeSetListener,
+            zonedDateTime.hour,
+            zonedDateTime.minute,
+            false
+        )
+        dialog.window?.setBackgroundDrawableResource(android.R.color.transparent)
+        dialog.show()
     }
 }

--- a/presentation/register/src/main/java/com/depromeet/threedays/register/update/GoalUpdateActivity.kt
+++ b/presentation/register/src/main/java/com/depromeet/threedays/register/update/GoalUpdateActivity.kt
@@ -1,0 +1,12 @@
+package com.depromeet.threedays.register.update
+
+import androidx.appcompat.app.AppCompatActivity
+import android.os.Bundle
+import com.depromeet.threedays.register.R
+
+class GoalUpdateActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_goal_update)
+    }
+}

--- a/presentation/register/src/main/java/com/depromeet/threedays/register/update/GoalUpdateViewModel.kt
+++ b/presentation/register/src/main/java/com/depromeet/threedays/register/update/GoalUpdateViewModel.kt
@@ -1,0 +1,103 @@
+package com.depromeet.threedays.register.update
+
+import androidx.lifecycle.viewModelScope
+import com.depromeet.threedays.core.BaseViewModel
+import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.launch
+import java.time.ZoneId
+import java.time.ZonedDateTime
+
+class GoalUpdateViewModel : BaseViewModel() {
+    private val _action = MutableSharedFlow<Action>()
+    val action: SharedFlow<Action>
+        get() = _action.asSharedFlow()
+
+    private val _goal = MutableStateFlow(
+        SimpleGoal(
+            title = MutableStateFlow(""),
+            startDate = ZonedDateTime.now(ZoneId.systemDefault()),
+            endDate = ZonedDateTime.now(ZoneId.systemDefault()),
+            startTime = ZonedDateTime.now(ZoneId.systemDefault()),
+            notificationTime = ZonedDateTime.now(ZoneId.systemDefault()),
+            notificationContent = ""
+        )
+    )
+    val goal: StateFlow<SimpleGoal>
+        get() = _goal.asStateFlow()
+
+    fun onStartCalendarClick() {
+        viewModelScope.launch {
+            val today = ZonedDateTime.now(ZoneId.systemDefault())
+            _action.emit(Action.StartCalendarClick(getRealDate(today, goal.value.startDate)))
+        }
+    }
+
+    fun onEndCalendarClick() {
+        viewModelScope.launch {
+            val today = ZonedDateTime.now(ZoneId.systemDefault())
+            _action.emit(Action.EndCalendarClick(getRealDate(today, goal.value.endDate)))
+        }
+    }
+
+    fun onRunTimeClick() {
+        viewModelScope.launch {
+            val today = ZonedDateTime.now(ZoneId.systemDefault())
+            _action.emit(Action.RunTimeClick(getRealDate(today, goal.value.startTime)))
+        }
+    }
+
+    private fun getRealDate(today: ZonedDateTime, currentDate: ZonedDateTime): ZonedDateTime {
+        return if (today == currentDate) today else currentDate
+    }
+
+    fun setStartDate(newYear: Int, newMonth: Int, newDay: Int) {
+        viewModelScope.launch {
+            _goal.value = _goal.value.copy(
+                startDate = _goal.value.startDate
+                    .withYear(newYear)
+                    .withMonth(newMonth)
+                    .withDayOfMonth(newDay)
+            )
+        }
+
+    }
+
+    fun setEndDate(newYear: Int, newMonth: Int, newDay: Int) {
+        viewModelScope.launch {
+            _goal.value = _goal.value.copy(
+                endDate = _goal.value.endDate
+                    .withYear(newYear)
+                    .withMonth(newMonth)
+                    .withDayOfMonth(newDay)
+            )
+        }
+    }
+
+    fun setStartTimeWithNotificationTime(newHour: Int, newMin: Int) {
+        viewModelScope.launch {
+            _goal.value = _goal.value.copy(
+                startTime = _goal.value.startTime
+                    .withHour(newHour)
+                    .withMinute(newMin),
+                notificationTime = _goal.value.notificationTime
+                    .withHour(newHour)
+                    .withMinute(newMin)
+            )
+        }
+    }
+
+    sealed class Action {
+        data class StartCalendarClick(val currentDate: ZonedDateTime) : Action()
+        data class EndCalendarClick(val currentDate: ZonedDateTime) : Action()
+        data class RunTimeClick(val currentTime: ZonedDateTime) : Action()
+    }
+
+    data class SimpleGoal(
+        val title: MutableStateFlow<String>,
+        var startDate: ZonedDateTime,
+        var endDate: ZonedDateTime,
+        var startTime: ZonedDateTime,
+        var notificationTime: ZonedDateTime,
+        var notificationContent: String
+    )
+}

--- a/presentation/register/src/main/res/layout/activity_goal_add.xml
+++ b/presentation/register/src/main/res/layout/activity_goal_add.xml
@@ -7,13 +7,13 @@
 
         <variable
             name="viewModel"
-            type="com.depromeet.threedays.register.GoalAddViewModel" />
+            type="com.depromeet.threedays.register.add.GoalAddViewModel" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        tools:context=".GoalAddActivity"
+        tools:context=".add.GoalAddActivity"
         tools:ignore="ContentDescription">
 
         <ImageView

--- a/presentation/register/src/main/res/layout/activity_goal_update.xml
+++ b/presentation/register/src/main/res/layout/activity_goal_update.xml
@@ -335,6 +335,7 @@
             android:enabled="@{!viewModel.goal.title.empty}"
             android:fontFamily="@font/suit_bold"
             android:gravity="center"
+            android:onClick="@{()->viewModel.onUpdateGoalClick()}"
             android:paddingVertical="15dp"
             android:text="@string/three_days_goal_save"
             android:textColor="@color/white"

--- a/presentation/register/src/main/res/layout/activity_goal_update.xml
+++ b/presentation/register/src/main/res/layout/activity_goal_update.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".update.GoalUpdateActivity">
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/presentation/register/src/main/res/layout/activity_goal_update.xml
+++ b/presentation/register/src/main/res/layout/activity_goal_update.xml
@@ -1,9 +1,346 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    tools:context=".update.GoalUpdateActivity">
+    xmlns:tools="http://schemas.android.com/tools">
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+    <data>
+
+        <variable
+            name="viewModel"
+            type="com.depromeet.threedays.register.update.GoalUpdateViewModel" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:context=".update.GoalUpdateActivity"
+        tools:ignore="ContentDescription">
+
+        <ImageView
+            android:id="@+id/iv_close"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="33dp"
+            android:layout_marginEnd="16dp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:srcCompat="@drawable/ic_close" />
+
+        <TextView
+            android:id="@+id/tv_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="20dp"
+            android:layout_marginTop="7dp"
+            android:fontFamily="@font/suit_bold"
+            android:text="@string/three_days_goal_update_title"
+            android:textColor="#1A1F27"
+            android:textSize="24sp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/iv_close" />
+
+        <TextView
+            android:id="@+id/tv_goal"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="20dp"
+            android:fontFamily="@font/suit_semi_bold"
+            android:text="@string/three_days_goal"
+            android:textColor="@color/gray4"
+            android:textSize="15sp"
+            app:layout_constraintStart_toStartOf="@+id/tv_title"
+            app:layout_constraintTop_toBottomOf="@+id/tv_title" />
+
+        <EditText
+            android:id="@+id/et_goal_name"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="20dp"
+            android:layout_marginTop="10dp"
+            android:background="@drawable/bg_rect_gray1_r10"
+            android:fontFamily="@font/suit_medium"
+            android:hint="@string/three_days_goal_input_request"
+            android:importantForAutofill="no"
+            android:inputType="text"
+            android:maxLength="15"
+            android:paddingVertical="13dp"
+            android:paddingStart="20dp"
+            android:paddingEnd="62dp"
+            android:text="@={viewModel.goal.title}"
+            android:textColor="@color/gray3"
+            android:textSize="15sp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/tv_goal"
+            tools:ignore="LabelFor"
+            tools:text="아침마다 물마시기" />
+
+        <TextView
+            android:id="@+id/tv_goal_counter"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="15dp"
+            android:fontFamily="@font/suit_medium"
+            android:text="@string/three_days_goal_name_count_default"
+            android:textColor="@color/gray2"
+            android:textSize="12sp"
+            app:layout_constraintBottom_toBottomOf="@+id/et_goal_name"
+            app:layout_constraintEnd_toEndOf="@+id/et_goal_name"
+            app:layout_constraintTop_toTopOf="@+id/et_goal_name" />
+
+        <TextView
+            android:id="@+id/tv_goal_period"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="25dp"
+            android:fontFamily="@font/suit_semi_bold"
+            android:text="@string/three_days_goal_period"
+            android:textColor="@color/gray4"
+            android:textSize="15sp"
+            app:layout_constraintStart_toStartOf="@+id/et_goal_name"
+            app:layout_constraintTop_toBottomOf="@+id/et_goal_name" />
+
+        <Switch
+            android:id="@+id/sw_goal_period"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="28dp"
+            android:checked="true"
+            android:switchMinWidth="30dp"
+            android:thumb="@drawable/selector_switch_button_thumb"
+            android:track="@drawable/selector_switch_button_track"
+            app:layout_constraintBottom_toBottomOf="@+id/tv_goal_period"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="@+id/tv_goal_period"
+            tools:ignore="UseSwitchCompatOrMaterialXml" />
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/cl_period"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="20dp"
+            android:layout_marginTop="10dp"
+            android:background="@drawable/bg_rect_gray1_r10"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/tv_goal_period">
+
+            <View
+                android:id="@+id/v_middle"
+                android:layout_width="match_parent"
+                android:layout_height="1dp"
+                android:background="#F1F1F1"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <TextView
+                android:id="@+id/tv_start"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginVertical="13dp"
+                android:layout_marginStart="20dp"
+                android:fontFamily="@font/suit_semi_bold"
+                android:text="@string/three_days_goal_start"
+                android:textColor="@color/gray5"
+                android:textSize="15sp"
+                app:layout_constraintBottom_toTopOf="@id/v_middle"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <TextView
+                android:id="@+id/tv_start_date"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginVertical="13dp"
+                android:layout_marginEnd="20dp"
+                android:fontFamily="@font/suit_medium"
+                android:text="@{String.format(`%d. %02d. %02d`, viewModel.goal.startDate.year, viewModel.goal.startDate.monthValue, viewModel.goal.startDate.dayOfMonth)}"
+                android:textColor="@color/gray3"
+                android:textSize="15sp"
+                app:layout_constraintBottom_toTopOf="@+id/v_middle"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                tools:text="2022. 10. 13" />
+
+            <TextView
+                android:id="@+id/tv_end"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginVertical="13dp"
+                android:layout_marginStart="20dp"
+                android:fontFamily="@font/suit_semi_bold"
+                android:text="@string/three_days_goal_end"
+                android:textColor="@color/gray5"
+                android:textSize="15sp"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/v_middle" />
+
+            <TextView
+                android:id="@+id/tv_end_date"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginVertical="13dp"
+                android:layout_marginEnd="20dp"
+                android:fontFamily="@font/suit_medium"
+                android:text="@{String.format(`%d. %02d. %02d`, viewModel.goal.endDate.year, viewModel.goal.endDate.monthValue, viewModel.goal.endDate.dayOfMonth)}"
+                android:textColor="@color/gray3"
+                android:textSize="15sp"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/v_middle"
+                tools:text="2022. 11 .13" />
+
+            <View
+                android:id="@+id/start_click_sections"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:onClick="@{()->viewModel.onStartCalendarClick()}"
+                app:layout_constraintBottom_toTopOf="@id/end_click_sections"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintVertical_weight="1" />
+
+            <View
+                android:id="@+id/end_click_sections"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:onClick="@{()->viewModel.onEndCalendarClick()}"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/start_click_sections"
+                app:layout_constraintVertical_weight="1" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+        <TextView
+            android:id="@+id/tv_run_time_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="25dp"
+            android:fontFamily="@font/suit_semi_bold"
+            android:text="@string/three_days_run_time"
+            android:textColor="@color/gray4"
+            android:textSize="15sp"
+            app:layout_constraintStart_toStartOf="@+id/et_goal_name"
+            app:layout_constraintTop_toBottomOf="@+id/cl_period" />
+
+        <Switch
+            android:id="@+id/sw_run_time"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="28dp"
+            android:checked="true"
+            android:switchMinWidth="30dp"
+            android:thumb="@drawable/selector_switch_button_thumb"
+            android:track="@drawable/selector_switch_button_track"
+            app:layout_constraintBottom_toBottomOf="@+id/tv_run_time_title"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="@+id/tv_run_time_title"
+            tools:ignore="UseSwitchCompatOrMaterialXml" />
+
+        <TextView
+            android:id="@+id/tv_run_time"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="20dp"
+            android:layout_marginTop="10dp"
+            android:background="@drawable/bg_rect_gray1_r10"
+            android:fontFamily="@font/suit_medium"
+            android:hint="@string/three_days_run_time_select_request"
+            android:onClick="@{()->viewModel.onRunTimeClick()}"
+            android:paddingHorizontal="20dp"
+            android:paddingVertical="13dp"
+            android:textColor="@color/gray3"
+            android:textSize="15sp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/tv_run_time_title" />
+
+        <TextView
+            android:id="@+id/tv_notification_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="25dp"
+            android:fontFamily="@font/suit_semi_bold"
+            android:text="@string/three_days_push_notification"
+            android:textColor="@color/gray4"
+            android:textSize="15sp"
+            app:layout_constraintStart_toStartOf="@+id/et_goal_name"
+            app:layout_constraintTop_toBottomOf="@+id/tv_run_time" />
+
+        <TextView
+            android:id="@+id/tv_notification"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="20dp"
+            android:layout_marginTop="10dp"
+            android:background="@drawable/bg_rect_gray1_r10"
+            android:fontFamily="@font/suit_medium"
+            android:hint="@string/three_days_run_time_select_request"
+            android:paddingHorizontal="20dp"
+            android:paddingVertical="13dp"
+            android:textColor="@color/gray3"
+            android:textSize="15sp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/tv_notification_title" />
+
+        <EditText
+            android:id="@+id/et_notification_content"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="20dp"
+            android:layout_marginTop="7dp"
+            android:background="@drawable/bg_rect_gray1_r10"
+            android:fontFamily="@font/suit_medium"
+            android:hint="@string/three_days_notification_content_request"
+            android:importantForAutofill="no"
+            android:inputType="text"
+            android:maxLength="20"
+            android:paddingHorizontal="20dp"
+            android:paddingTop="15dp"
+            android:paddingBottom="42dp"
+            android:text="@={viewModel.goal.notificationContent}"
+            android:textColor="@color/gray3"
+            android:textSize="15sp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/tv_notification"
+            tools:ignore="LabelFor" />
+
+        <TextView
+            android:id="@+id/tv_notification_counter"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="11dp"
+            android:layout_marginBottom="6dp"
+            android:fontFamily="@font/suit_medium"
+            android:text="@string/three_days_notification_count_default"
+            android:textColor="@color/gray2"
+            android:textSize="12sp"
+            app:layout_constraintBottom_toBottomOf="@+id/et_notification_content"
+            app:layout_constraintEnd_toEndOf="@+id/et_notification_content" />
+
+        <TextView
+            android:id="@+id/tv_goal_save"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="20dp"
+            android:layout_marginBottom="20dp"
+            android:background="@drawable/selector_goal_create_button"
+            android:enabled="@{!viewModel.goal.title.empty}"
+            android:fontFamily="@font/suit_bold"
+            android:gravity="center"
+            android:paddingVertical="15dp"
+            android:text="@string/three_days_goal_save"
+            android:textColor="@color/white"
+            android:textSize="16sp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/presentation/register/src/main/res/values/strings.xml
+++ b/presentation/register/src/main/res/values/strings.xml
@@ -1,5 +1,6 @@
 <resources>
-    <string name="three_days_goal_create_title">짝심 목표 만들기</string>
+    <!--짝심 목표 생성-->
+    <string name="three_days_goal_create_title">짝심목표 만들기</string>
     <string name="three_days_goal">목표</string>
     <string name="three_days_goal_input_request">짝심 목표를 알려주세요</string>
     <string name="three_days_goal_start">시작</string>
@@ -14,4 +15,8 @@
     <string name="three_days_notification_count_default">0/20</string>
     <string name="three_days_time_afternoon_format">오후 %02d:%02d</string>
     <string name="three_days_time_morning_format">오전 %02d:%02d</string>
+
+    <!--짝심 목표 수정-->
+    <string name="three_days_goal_update_title">짝심목표 수정하기</string>
+    <string name="three_days_goal_save">저장</string>
 </resources>


### PR DESCRIPTION
## 💁‍♂️ 변경 내용
### AS-IS
 목표 수정 페이지가 존재하지 않았습니다.

### TO-BE
![image](https://user-images.githubusercontent.com/68214704/197389789-7654843a-18f2-49b6-b115-b0a3b0df7651.png)

- 목표 수정 페이지 그리기
- 목표 수정 페이지 뷰에 대한 이벤트 설정
- 로컬 디비와 연동 (데이터 불러오기 & 데이터 업데이트)

## 📢 전달사항
SimpleGoal을 계속 사용하는건 Goal에 대한 conflict 피해를.. 최소화하고자 일단 저렇게 해놨습니다
추후 Goal 등 확정이 되면 변경되거나 사라질 클래스입니다!

Goal에 대한 클래스나 mapper도 제가 임시로 변경한거라 언제든지 .. 변경하셔도.. 괜찮습니다!