### PR TITLE
DEP-51 feature: 목표 만들기 페이지로 이동 기능 구현 (Navigator)

### DIFF
--- a/navigator/src/main/java/com/depromeet/threedays/navigator/GoalAddNavigator.kt
+++ b/navigator/src/main/java/com/depromeet/threedays/navigator/GoalAddNavigator.kt
@@ -1,0 +1,3 @@
+package com.depromeet.threedays.navigator
+
+interface GoalAddNavigator : Navigator

--- a/navigator/src/main/java/com/depromeet/threedays/navigator/GoalUpdateNavigator.kt
+++ b/navigator/src/main/java/com/depromeet/threedays/navigator/GoalUpdateNavigator.kt
@@ -1,0 +1,3 @@
+package com.depromeet.threedays.navigator
+
+interface GoalUpdateNavigator : Navigator

--- a/presentation/home/src/main/java/com/depromeet/threedays/home/home/HomeFragment.kt
+++ b/presentation/home/src/main/java/com/depromeet/threedays/home/home/HomeFragment.kt
@@ -10,12 +10,21 @@ import com.depromeet.threedays.core.BaseFragment
 import com.depromeet.threedays.domain.entity.Goal
 import com.depromeet.threedays.home.R
 import com.depromeet.threedays.home.databinding.FragmentHomeBinding
+import com.depromeet.threedays.navigator.GoalAddNavigator
+import com.depromeet.threedays.navigator.GoalUpdateNavigator
 import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class HomeFragment : BaseFragment<FragmentHomeBinding, HomeViewModel>(R.layout.fragment_home) {
     override val viewModel by viewModels<HomeViewModel>()
     lateinit var goalAdapter: GoalAdapter
+
+    @Inject
+    lateinit var goalAddNavigator: GoalAddNavigator
+
+    @Inject
+    lateinit var goalUpdateNavigator: GoalUpdateNavigator
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -35,13 +44,6 @@ class HomeFragment : BaseFragment<FragmentHomeBinding, HomeViewModel>(R.layout.f
     }
 
     private fun initView() {
-        // 우선 임시로 setOnClickListener를 달아놨습니다.
-        // 혜인님 레포에 있는 것처럼 setOnSingleClickListener를 만들어서 사용할 지 여부와
-        // viewModel에서 클릭리스너를 달아줄지 등을 협의하고 확정되면 추후에 수정하겠습니다.
-        binding.btnMakeGoal.setOnClickListener {
-            // TODO: 만들기 페이지로 이동
-        }
-
         binding.rvGoal.apply {
             layoutManager = LinearLayoutManager(requireContext())
             adapter = goalAdapter
@@ -58,7 +60,13 @@ class HomeFragment : BaseFragment<FragmentHomeBinding, HomeViewModel>(R.layout.f
         }
 
         binding.ivPlus.setOnClickListener {
-            tempCreateData()
+            // 임시 데이터 만들고 싶을 때 사용할 것 (나중에 삭제할 예정)
+            // tempCreateData()
+            startActivity(goalAddNavigator.intent(requireContext()))
+        }
+
+        binding.btnMakeGoal.setOnClickListener {
+            startActivity(goalAddNavigator.intent(requireContext()))
         }
     }
 
@@ -66,6 +74,10 @@ class HomeFragment : BaseFragment<FragmentHomeBinding, HomeViewModel>(R.layout.f
         goals.observe(viewLifecycleOwner) {
             goalAdapter.submitList(it)
             goalAdapter.notifyDataSetChanged()
+
+            binding.clNoGoal.visibility = if(it.isEmpty()) View.VISIBLE else View.GONE
+            binding.rvGoal.visibility = if(it.isEmpty()) View.GONE else View.VISIBLE
+            binding.ivPlus.visibility = if(it.isEmpty()) View.GONE else View.VISIBLE
         }
     }
 

--- a/presentation/home/src/main/res/layout/fragment_home.xml
+++ b/presentation/home/src/main/res/layout/fragment_home.xml
@@ -55,6 +55,7 @@
 
         <!-- 등록된 목표가 없는 경우에 보여지는 레이아웃 -->
         <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/cl_no_goal"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="32dp"

--- a/presentation/register/src/main/java/com/depromeet/threedays/register/add/GoalAddModule.kt
+++ b/presentation/register/src/main/java/com/depromeet/threedays/register/add/GoalAddModule.kt
@@ -1,0 +1,15 @@
+package com.depromeet.threedays.register.add
+
+import com.depromeet.threedays.navigator.GoalAddNavigator
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+@Module
+@InstallIn(SingletonComponent::class)
+internal abstract class GoalAddModule {
+
+    @Binds
+    abstract fun bindGoalAddNavigator(navi: GoalAddNavigatorImpl): GoalAddNavigator
+}

--- a/presentation/register/src/main/java/com/depromeet/threedays/register/add/GoalAddNavigatorImpl.kt
+++ b/presentation/register/src/main/java/com/depromeet/threedays/register/add/GoalAddNavigatorImpl.kt
@@ -1,0 +1,12 @@
+package com.depromeet.threedays.register.add
+
+import android.content.Context
+import android.content.Intent
+import com.depromeet.threedays.navigator.GoalAddNavigator
+import javax.inject.Inject
+
+class GoalAddNavigatorImpl @Inject constructor() : GoalAddNavigator {
+    override fun intent(context: Context): Intent {
+        return Intent(context, GoalAddActivity::class.java)
+    }
+}

--- a/presentation/register/src/main/java/com/depromeet/threedays/register/update/GoalUpdateModule.kt
+++ b/presentation/register/src/main/java/com/depromeet/threedays/register/update/GoalUpdateModule.kt
@@ -1,0 +1,15 @@
+package com.depromeet.threedays.register.update
+
+import com.depromeet.threedays.navigator.GoalUpdateNavigator
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+@Module
+@InstallIn(SingletonComponent::class)
+internal abstract class GoalUpdateModule {
+
+    @Binds
+    abstract fun bindGoalUpdateNavigator(navi: GoalUpdateNavigatorImpl): GoalUpdateNavigator
+}

--- a/presentation/register/src/main/java/com/depromeet/threedays/register/update/GoalUpdateNavigatorImpl.kt
+++ b/presentation/register/src/main/java/com/depromeet/threedays/register/update/GoalUpdateNavigatorImpl.kt
@@ -1,0 +1,12 @@
+package com.depromeet.threedays.register.update
+
+import android.content.Context
+import android.content.Intent
+import com.depromeet.threedays.navigator.GoalUpdateNavigator
+import javax.inject.Inject
+
+class GoalUpdateNavigatorImpl @Inject constructor() : GoalUpdateNavigator {
+    override fun intent(context: Context): Intent {
+        return Intent(context, GoalUpdateActivity::class.java)
+    }
+}


### PR DESCRIPTION
## 💁‍♂️ 변경 내용
### AS-IS
- 홈에서 목표 만들기 페이지로 이동할 수 없었습니다.
- 리스트 개수에 상관없이 항상 같은 화면이 보였습니다.

### TO-BE
- 이제 목표 만들기 혹은 추가 버튼을 누르면 목표 만들기 페이지로 이동합니다.
- 리스트가 없을 때와 있을 때 다른 화면을 보여줍니다.

## 📢 전달사항
- 수정 페이지로 넘어갈 때 필요한 파일들도 추가해두었습니다. BottomSheet 완성되면 startActivity만 하면 됩니다.