### PR TITLE
DEP-90 feat:(임시) primary color 값 변경 및 목표생성화면 에러 해결

### DIFF
--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <color name="purple_200">#FFBB86FC</color>
-    <color name="purple_500">#FF6200EE</color>
+    <color name="purple_500">#3266CC</color>
     <color name="purple_700">#FF3700B3</color>
-    <color name="teal_200">#FF03DAC5</color>
+    <color name="teal_200">#3F80FF</color>
     <color name="teal_700">#FF018786</color>
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>

--- a/presentation/register/src/main/java/com/depromeet/threedays/register/add/GoalAddActivity.kt
+++ b/presentation/register/src/main/java/com/depromeet/threedays/register/add/GoalAddActivity.kt
@@ -83,6 +83,8 @@ class GoalAddActivity : BaseActivity<ActivityGoalAddBinding>(R.layout.activity_g
                 is EndCalendarClick -> showDatePicker(action.currentDate, false)
                 is RunTimeClick -> showTimePicker(action.currentTime)
                 is SaveClick -> {
+                    binding.etGoalName.text = null
+                    binding.etNotificationContent.text = null
                     setResult(RESULT_CREATE)
                     finish()
                 }


### PR DESCRIPTION
## 💁‍♂️ 변경 내용
### AS-IS
- 안드로이드 기본 primary color였습니다.
- 목표 생성 화면의 데이터들이 화면이 finish 되고 다시 생성하러 들어가면 이전 데이터가 남아있었습니다.
### TO-BE
- primary color의 값을 임시로 짝심삼일의 메인컬러로 변경했습니다. (임시)
- finish 전 해당 데이터를 null로 만들어 에러를 해결했습니다 (임시)
## 📢 전달사항
위 두가지 사항은 임시로 변경 & 해결 한 코드라 추후 수정 예정입니다