### PR TITLE
DEP-116 feat: 지정해둔 아이템을 생성하는 임시 버튼 추가

### DIFF
--- a/presentation/home/src/main/java/com/depromeet/threedays/home/home/HomeFragment.kt
+++ b/presentation/home/src/main/java/com/depromeet/threedays/home/home/HomeFragment.kt
@@ -141,6 +141,11 @@ class HomeFragment : BaseFragment<FragmentHomeBinding, HomeViewModel>(R.layout.f
             addResultLauncher.launch(goalAddNavigator.intent(requireContext()))
         }
 
+        binding.tvHeader.setOnLongClickListener {
+            addThreeTypesOfGoal()
+            true
+        }
+
         val now = ZonedDateTime.now(ZoneId.systemDefault())
         val dayOfWeekList = listOf("월", "화", "수", "목", "금", "토", "일")
         binding.tvDate.text = String.format("%02d. %02d (%s)", now.monthValue, now.dayOfMonth, dayOfWeekList[now.dayOfWeek.value - 1])
@@ -194,5 +199,24 @@ class HomeFragment : BaseFragment<FragmentHomeBinding, HomeViewModel>(R.layout.f
 
     private fun dpToPx(dp: Int): Int {
         return TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, dp.toFloat(), requireContext().resources.displayMetrics).toInt()
+    }
+
+    private fun addThreeTypesOfGoal() {
+        CustomToast().showTextToast(
+            requireContext(),
+            "리스트를 초기값으로 변경합니다"
+        )
+
+        viewModel.updateGoals(
+            UpdateGoalRequest(
+                goalId = 1,
+                "책 10페이지 읽기",
+                sequence = 10,
+                clapIndex = 2,
+                clapChecked = false
+            )
+        )
+
+        viewModel.fetchGoals()
     }
 }


### PR DESCRIPTION
## 💁‍♂️ 변경 내용
### AS-IS
- 아이템을 직접 생성해야 해서 2일차까지 완료된 아이템을 테스트할 수 없었음

### TO-BE
<img src="https://user-images.githubusercontent.com/76620764/198675105-d46772d9-7672-4da9-9708-09c738c615af.gif" width="400"/>

디자이너 분들의 요청으로 UT를 위해 버튼을 만들었습니다.
header text를 long click 하면 id가 1인 아이템을 2일차까지 완성된 아이템으로 업데이트 해줍니다.

## 📢 전달사항
UT가 끝난 후 삭제될 기능입니다.