### PR TITLE
DEP-108 feat: 할일 완료/미완료 시 짝심 N일 값 변경 & flow를 사용하여 실시간 반영

### DIFF
--- a/data/src/main/java/com/depromeet/threedays/data/repository/GoalRepositoryImpl.kt
+++ b/data/src/main/java/com/depromeet/threedays/data/repository/GoalRepositoryImpl.kt
@@ -7,14 +7,16 @@ import com.depromeet.threedays.domain.entity.Goal
 import com.depromeet.threedays.domain.entity.request.SaveGoalRequest
 import com.depromeet.threedays.domain.entity.request.UpdateGoalRequest
 import com.depromeet.threedays.domain.repository.GoalRepository
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 
 class GoalRepositoryImpl @Inject constructor(
     private val goalDataSource: GoalDataSource
 ) : GoalRepository {
-    override suspend fun findAll(): List<Goal> {
-        return goalDataSource.getGoals().first().map { it.toGoal() }
+    override suspend fun findAll(): Flow<List<Goal>> {
+        return goalDataSource.getGoals().map { it.map { it.toGoal() } }
     }
 
     override suspend fun findById(goalId: Long): Goal {

--- a/domain/build.gradle
+++ b/domain/build.gradle
@@ -10,4 +10,5 @@ java {
 
 dependencies {
     implementation deps.inject
+    implementation(coroutines)
 }

--- a/domain/src/main/java/com/depromeet/threedays/domain/repository/GoalRepository.kt
+++ b/domain/src/main/java/com/depromeet/threedays/domain/repository/GoalRepository.kt
@@ -3,9 +3,10 @@ package com.depromeet.threedays.domain.repository
 import com.depromeet.threedays.domain.entity.Goal
 import com.depromeet.threedays.domain.entity.request.SaveGoalRequest
 import com.depromeet.threedays.domain.entity.request.UpdateGoalRequest
+import kotlinx.coroutines.flow.Flow
 
 interface GoalRepository {
-    suspend fun findAll(): List<Goal>
+    suspend fun findAll(): Flow<List<Goal>>
     suspend fun findById(goalId: Long): Goal
     suspend fun create(goal: SaveGoalRequest)
     suspend fun update(goal: UpdateGoalRequest)

--- a/domain/src/main/java/com/depromeet/threedays/domain/usecase/GetAllGoalsUseCase.kt
+++ b/domain/src/main/java/com/depromeet/threedays/domain/usecase/GetAllGoalsUseCase.kt
@@ -2,13 +2,14 @@ package com.depromeet.threedays.domain.usecase
 
 import com.depromeet.threedays.domain.entity.Goal
 import com.depromeet.threedays.domain.repository.GoalRepository
+import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 
 class GetAllGoalsUseCase @Inject constructor(
     private val goalRepository: GoalRepository
 ) {
 
-    suspend operator fun invoke(): List<Goal> {
+    suspend operator fun invoke(): Flow<List<Goal>> {
         return goalRepository.findAll()
     }
 

--- a/presentation/home/src/main/java/com/depromeet/threedays/home/home/GoalAdapter.kt
+++ b/presentation/home/src/main/java/com/depromeet/threedays/home/home/GoalAdapter.kt
@@ -28,7 +28,7 @@ class GoalAdapter(
     companion object {
         private val DIFF_UTIL = object : DiffUtil.ItemCallback<Goal>() {
             override fun areItemsTheSame(oldItem: Goal, newItem: Goal): Boolean {
-                return oldItem == newItem
+                return oldItem.goalId == newItem.goalId
             }
 
             override fun areContentsTheSame(oldItem: Goal, newItem: Goal): Boolean {

--- a/presentation/home/src/main/java/com/depromeet/threedays/home/home/HomeFragment.kt
+++ b/presentation/home/src/main/java/com/depromeet/threedays/home/home/HomeFragment.kt
@@ -6,6 +6,9 @@ import android.util.TypedValue
 import android.view.View
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.depromeet.threedays.core.BaseFragment
@@ -20,6 +23,7 @@ import com.depromeet.threedays.home.databinding.FragmentHomeBinding
 import com.depromeet.threedays.navigator.GoalAddNavigator
 import com.depromeet.threedays.navigator.GoalUpdateNavigator
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
 import java.time.ZoneId
 import java.time.ZonedDateTime
 import javax.inject.Inject
@@ -78,7 +82,7 @@ class HomeFragment : BaseFragment<FragmentHomeBinding, HomeViewModel>(R.layout.f
             startTime = if(goal.startTime == null) null else goal.startTime,
             notificationTime = if(goal.notificationTime == null) null else goal.notificationTime,
             notificationContent = goal.notificationContent,
-            sequence = goal.sequence,
+            sequence = goal.sequence + if(goal.clapChecked) 1 else -1,
             clapIndex = goal.clapIndex,
             clapChecked = goal.clapChecked,
             lastAchievementDate = lastAchievementDate,
@@ -147,14 +151,18 @@ class HomeFragment : BaseFragment<FragmentHomeBinding, HomeViewModel>(R.layout.f
     }
 
     private fun HomeViewModel.setObserve() {
-        goals.observe(viewLifecycleOwner) {
-            //val sequenceCheckedList = checkGoalSequence(it)
-            goalAdapter.submitList(it)
-            goalAdapter.notifyDataSetChanged()
+        lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.apply {
+                    goals.collect {
+                        goalAdapter.submitList(it)
 
-            binding.clNoGoal.visibility = if(it.isEmpty()) View.VISIBLE else View.GONE
-            binding.rvGoal.visibility = if(it.isEmpty()) View.GONE else View.VISIBLE
-            binding.ivPlus.visibility = if(it.isEmpty()) View.GONE else View.VISIBLE
+                        binding.clNoGoal.visibility = if (it.isEmpty()) View.VISIBLE else View.GONE
+                        binding.rvGoal.visibility = if (it.isEmpty()) View.GONE else View.VISIBLE
+                        binding.ivPlus.visibility = if (it.isEmpty()) View.GONE else View.VISIBLE
+                    }
+                }
+            }
         }
     }
 

--- a/presentation/home/src/main/java/com/depromeet/threedays/home/home/HomeViewModel.kt
+++ b/presentation/home/src/main/java/com/depromeet/threedays/home/home/HomeViewModel.kt
@@ -1,7 +1,5 @@
 package com.depromeet.threedays.home.home
 
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.viewModelScope
 import com.depromeet.threedays.core.BaseViewModel
 import com.depromeet.threedays.domain.entity.Goal
@@ -10,6 +8,8 @@ import com.depromeet.threedays.domain.usecase.DeleteGoalUseCase
 import com.depromeet.threedays.domain.usecase.GetAllGoalsUseCase
 import com.depromeet.threedays.domain.usecase.UpdateGoalUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -20,15 +20,14 @@ class HomeViewModel @Inject constructor(
     private val deleteGoalUseCase: DeleteGoalUseCase,
 ) : BaseViewModel() {
 
-    private val _goals: MutableLiveData<List<Goal>> = MutableLiveData(emptyList())
-    val goals: LiveData<List<Goal>>
+    private val _goals: MutableStateFlow<List<Goal>> = MutableStateFlow(emptyList())
+    val goals: StateFlow<List<Goal>>
         get() = _goals
 
     fun fetchGoals() {
         viewModelScope.launch {
-            val response = getAllGoalsUseCase()
-            if (response != null) {
-                _goals.postValue(response)
+            getAllGoalsUseCase().collect {
+                _goals.value = it
             }
         }
     }


### PR DESCRIPTION
## 💁‍♂️ 변경 내용
### AS-IS
- 할일 완료를 눌러도 짝심 일수가 변하지 않았습니다.
- 리스트 변경 사항이 실시간으로 이루어지지 않아 매번 fetchGoals()를 다시 호출했습니다.
- diffUtil의 areItemsTheSame에서 객체를 비교했습니다.

### TO-BE
- 이제 할일 완료/미완료 시 짝심 일수가 변합니다.
- 리스트 변경 사항이 실시간으로 반영됩니다.
- diffUtil의 areItemsTheSame에서 id를 비교합니다.
   - flow가 dao와 viewModel에서만 사용되고 있어 실시간 반영이 되지 않았습니다.

## 📢 전달사항
 
제가 추측한 `리스트가 실시간으로 반영되지 않았던 이유`는 다음과 같습니다.
flow는 파이프와 비슷하다고 합니다.
flow를 사용하면 db에서 부터 dataSource ... presentation까지 파이프로 연결되고 데이터가 파이프를 따라 흐른다고 합니다.
데이터를 받아서 사용하는 곳에서는 이를 collect를 하여 데이터의 변동 사항이 있으면 이를 감지하고 적용할 수 있는거죠.
근데 이전에는 `flow가` dao와 viewModel에서만 사용되고 있고 `중간 구간에서 다 빠져있었습니다.`
`파이프가 중간에 끊겨져 있었기 때문에 데이터 변경을 감지하지 못했던 게` 아닐까 싶습니다.

현재는 파이프를 다 연결해두었으나, 아쉬운 점은 useCase 즉, `domain 모듈에서 flow를 사용하기 위해 coroutine 라이브러리를 사용`한다는 것인데요... 순수한 코틀린 코드만 있어야 하는 domain에서 이래도 되는 것인지...
인터넷의 다른 예제에서는 그냥 쓰긴 하던데 🤔
만약 flow를 안 쓴다면 이를 어떻게 해결해야 하는지 잘 모르겠습니다.

그리고 diffUtil의 areItemsTheSame에서 id로 비교하는 이유는
id로 먼저 비교해서 같은 객체인가?를 판단하고
그 다음에 areContentsTheSame에서 내용까지 같은가?를 판단한다고 합니다.
저만 몰랐던 내용일수도... ㅎㅎ.. 아무튼 그래서 id로 바꿔두었습니다.