### PR TITLE
DEP-157 feat: dialog, taost util 제작

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="1.8" />
+    <bytecodeTargetLevel target="1.8">
+      <module name="ThreeDays.presentation.my" target="15" />
+      <module name="ThreeDays.presentation.statistics" target="15" />
+    </bytecodeTargetLevel>
   </component>
 </project>

--- a/core-design-system/src/main/res/drawable/bg_rect_gray200_r10.xml
+++ b/core-design-system/src/main/res/drawable/bg_rect_gray200_r10.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+
+    <solid android:color="@color/gray_200" />
+    <corners android:radius="10dp" />
+
+</shape>

--- a/core-design-system/src/main/res/drawable/bg_rect_gray700_r10.xml
+++ b/core-design-system/src/main/res/drawable/bg_rect_gray700_r10.xml
@@ -2,7 +2,7 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
 
-    <solid android:color="@color/main" />
+    <solid android:color="@color/gray_700" />
     <corners android:radius="10dp" />
 
 </shape>

--- a/core-design-system/src/main/res/drawable/bg_rect_gray800_r10.xml
+++ b/core-design-system/src/main/res/drawable/bg_rect_gray800_r10.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
-    <solid android:color="@color/toast" />
-    <corners android:radius="5dp" />
+
+    <solid android:color="@color/gray_800" />
+    <corners android:radius="10dp" />
+
 </shape>

--- a/core-design-system/src/main/res/drawable/bg_rect_main_r10.xml
+++ b/core-design-system/src/main/res/drawable/bg_rect_main_r10.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+
+    <solid android:color="@color/main" />
+    <corners android:radius="10dp" />
+
+</shape>

--- a/core-design-system/src/main/res/drawable/bg_rect_white_r18.xml
+++ b/core-design-system/src/main/res/drawable/bg_rect_white_r18.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+
+    <solid android:color="@color/white" />
+    <corners android:radius="18dp" />
+
+</shape>

--- a/core-design-system/src/main/res/drawable/ic_check_green.xml
+++ b/core-design-system/src/main/res/drawable/ic_check_green.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="16dp"
+    android:height="11dp"
+    android:viewportWidth="16"
+    android:viewportHeight="11">
+  <path
+      android:pathData="M6.6,10.2C6.3,10.2 6,10.1 5.8,9.8L1.2,5.2C0.7,4.7 0.7,4 1.2,3.5C1.7,3 2.4,3 2.9,3.5L6.6,7.2L13.2,0.6C13.7,0.1 14.4,0.1 14.9,0.6C15.4,1.1 15.4,1.8 14.9,2.3L7.5,9.7C7.2,10.1 6.9,10.2 6.6,10.2Z"
+      android:fillColor="#34C185"/>
+</vector>

--- a/core-design-system/src/main/res/values/colors.xml
+++ b/core-design-system/src/main/res/values/colors.xml
@@ -7,6 +7,8 @@
     <color name="disable">#ACACAC</color>
     <color name="toast">#3C3C3C</color>
 
+    <color name="main">#1A1E27</color>
+
     <color name="green_sub_color">#34C185</color>
     <color name="light_green_sub_color">#DFF5EC</color>
     <color name="blue_sub_color">#3F80FF</color>

--- a/core-design-system/src/main/res/values/colors.xml
+++ b/core-design-system/src/main/res/values/colors.xml
@@ -24,14 +24,15 @@
 
     <color name="white">#FFFFFF</color>
     <color name="gray_background">#F6F7F9</color>
-    <color name="gray_100">#F4F7FA</color>
+    <color name="gray_100">#F4F6F8</color>
     <color name="gray_200">#E8EBF0</color>
     <color name="gray_300">#D8DCE2</color>
     <color name="gray_400">#C4CAD4</color>
-    <color name="gray_500">#949494</color>
-    <color name="gray_600">#777777</color>
-    <color name="gray_700">#555555</color>
-    <color name="gray_800">#303030</color>
+    <color name="gray_450">#F4F6F8</color>
+    <color name="gray_500">#8E95A3</color>
+    <color name="gray_600">#5B616C</color>
+    <color name="gray_700">#353C49</color>
+    <color name="gray_800">#1A1E27</color>
     <color name="black">#121213</color>
 
     <color name="green_system_color">#09BC7B</color>

--- a/core-design-system/src/main/res/values/typography.xml
+++ b/core-design-system/src/main/res/values/typography.xml
@@ -70,15 +70,49 @@
         <item name="android:textSize" tools:ignore="SpUsage">24dp</item>
     </style>
 
+    <!-- Paragraph2 -->
+    <style name="Typography.Paragraph2">
+        <item name="fontFamily">@font/suit_medium</item>
+    </style>
+    <style name="Typography.Paragraph2.14dp">
+        <item name="android:textSize" tools:ignore="SpUsage">14dp</item>
+    </style>
+    <style name="Typography.Paragraph2.22dp">
+        <item name="android:textSize" tools:ignore="SpUsage">22dp</item>
+    </style>
+
+    <!-- Paragraph3 -->
+    <style name="Typography.Paragraph3">
+        <item name="fontFamily">@font/suit_medium</item>
+    </style>
+    <style name="Typography.Paragraph3.13dp">
+        <item name="android:textSize" tools:ignore="SpUsage">13dp</item>
+    </style>
+    <style name="Typography.Paragraph3.20dp">
+        <item name="android:textSize" tools:ignore="SpUsage">20dp</item>
+    </style>
+
     <!-- Caption -->
     <style name="Typography.Caption">
         <item name="android:textSize" tools:ignore="SpUsage">11dp</item>
         <item name="fontFamily">@font/suit_medium</item>
     </style>
 
-    <!-- Button -->
-    <style name="Typography.Button">
+    <!-- Button1 -->
+    <style name="Typography.Button1">
         <item name="android:textSize" tools:ignore="SpUsage">16dp</item>
+        <item name="fontFamily">@font/suit_bold</item>
+    </style>
+
+    <!-- Button2 -->
+    <style name="Typography.Button2">
+        <item name="android:textSize" tools:ignore="SpUsage">15dp</item>
+        <item name="fontFamily">@font/suit_bold</item>
+    </style>
+
+    <!-- Button3 -->
+    <style name="Typography.Button3">
+        <item name="android:textSize" tools:ignore="SpUsage">14dp</item>
         <item name="fontFamily">@font/suit_bold</item>
     </style>
 </resources>

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -8,11 +8,11 @@ plugins {
 }
 
 android {
-    compileSdk 32
+    compileSdk 33
 
     defaultConfig {
         minSdk 26
-        targetSdk 32
+        targetSdk 33
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"

--- a/core/src/main/java/com/depromeet/threedays/core/OnSingleClickListener.kt
+++ b/core/src/main/java/com/depromeet/threedays/core/OnSingleClickListener.kt
@@ -1,0 +1,46 @@
+package com.depromeet.threedays.core
+
+import android.os.SystemClock
+import android.view.View
+import androidx.databinding.BindingAdapter
+
+class OnSingleClickListener(
+    private val interval: Int,
+    private val onSingleClick: (View) -> Unit
+) : View.OnClickListener {
+
+    private var lastClickedTime: Long = 0L
+
+    override fun onClick(v: View) {
+        val elapsedRealTime = SystemClock.elapsedRealtime()
+        if ((elapsedRealTime - lastClickedTime) < interval) {
+            return
+        }
+        lastClickedTime = elapsedRealTime
+        onSingleClick(v)
+    }
+}
+
+fun View.setOnSingleClickListener(
+    interval: Int = 200,
+    onClick: (View) -> Unit = { }
+) {
+    setOnClickListener(OnSingleClickListener(interval, onClick))
+}
+
+@BindingAdapter("android:onClick", "throttleMillis", requireAll = false)
+fun setOnSingleClickListener(
+    view: View,
+    listener: View.OnClickListener?,
+    throttleMillis: Long? = 200
+) {
+    view.setOnClickListener(listener?.let {
+        View.OnClickListener {
+            val lastClickedAt = (view.getTag(R.id.last_click_at) as Long?) ?: 0L
+            if (System.currentTimeMillis() > lastClickedAt + (throttleMillis ?: 200L)) {
+                listener.onClick(view)
+                view.setTag(R.id.last_click_at, System.currentTimeMillis())
+            }
+        }
+    })
+}

--- a/core/src/main/java/com/depromeet/threedays/core/extensions/Int.kt
+++ b/core/src/main/java/com/depromeet/threedays/core/extensions/Int.kt
@@ -1,0 +1,4 @@
+package com.depromeet.threedays.core.extensions
+
+val Int.toEmoji
+    get() = String(Character.toChars(this))

--- a/core/src/main/java/com/depromeet/threedays/core/extensions/PixelExt.kt
+++ b/core/src/main/java/com/depromeet/threedays/core/extensions/PixelExt.kt
@@ -1,0 +1,11 @@
+package com.depromeet.threedays.core.extensions
+
+import android.content.res.Resources
+import android.util.TypedValue
+import kotlin.math.roundToInt
+
+val Int.dp: Int
+    @JvmSynthetic inline get() = TypedValue.applyDimension(
+        TypedValue.COMPLEX_UNIT_DIP, this.toFloat(),
+        Resources.getSystem().displayMetrics
+    ).roundToInt()

--- a/core/src/main/java/com/depromeet/threedays/core/extensions/String.kt
+++ b/core/src/main/java/com/depromeet/threedays/core/extensions/String.kt
@@ -1,0 +1,4 @@
+package com.depromeet.threedays.core.extensions
+
+val String.Companion.Empty
+    get() = ""

--- a/core/src/main/java/com/depromeet/threedays/core/extensions/View.kt
+++ b/core/src/main/java/com/depromeet/threedays/core/extensions/View.kt
@@ -1,0 +1,47 @@
+package com.depromeet.threedays.core.extensions
+
+import android.content.Context
+import android.util.TypedValue
+import android.view.View
+import android.view.ViewGroup
+import androidx.core.view.isInvisible
+import androidx.core.view.isVisible
+
+fun View.visible() {
+    this.isVisible = true
+}
+
+fun View.visibleOrGone(isVisible: Boolean) {
+    this.isVisible = isVisible
+}
+
+fun View.gone() {
+    this.isVisible = false
+}
+
+fun View.goneIfNeeded() {
+    if (isVisible) {
+        this.isVisible = false
+    }
+}
+
+fun View.invisible() {
+    this.isInvisible = true
+}
+
+fun View.margin(left: Float? = null, top: Float? = null, right: Float? = null, bottom: Float? = null) {
+    layoutParams<ViewGroup.MarginLayoutParams> {
+        left?.run { leftMargin = dpToPx(this) }
+        top?.run { topMargin = dpToPx(this) }
+        right?.run { rightMargin = dpToPx(this) }
+        bottom?.run { bottomMargin = dpToPx(this) }
+    }
+}
+
+inline fun <reified T : ViewGroup.LayoutParams> View.layoutParams(block: T.() -> Unit) {
+    if (layoutParams is T) block(layoutParams as T)
+}
+
+fun View.dpToPx(dp: Float): Int = context.dpToPx(dp)
+
+fun Context.dpToPx(dp: Float): Int = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, dp, resources.displayMetrics).toInt()

--- a/core/src/main/java/com/depromeet/threedays/core/util/ThreeDaysDialogFragment.kt
+++ b/core/src/main/java/com/depromeet/threedays/core/util/ThreeDaysDialogFragment.kt
@@ -1,0 +1,145 @@
+package com.depromeet.threedays.core.util
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.databinding.DataBindingUtil
+import androidx.fragment.app.DialogFragment
+import com.depromeet.threedays.core.R
+import com.depromeet.threedays.core.databinding.FragmentThreeDaysDialogBinding
+import com.depromeet.threedays.core.extensions.*
+import com.depromeet.threedays.core.setOnSingleClickListener
+import com.depromeet.threedays.core_design_system.R.drawable.bg_rect_white_r18
+
+class ThreeDaysDialogFragment : DialogFragment() {
+    private lateinit var onPositiveAction: () -> Unit
+    private var dialogMode: Int = NOT_INIT
+
+    private var _binding: FragmentThreeDaysDialogBinding? = null
+    private val binding get() = _binding!!
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding =
+            DataBindingUtil.inflate(inflater, R.layout.fragment_three_days_dialog, container, false)
+        binding.lifecycleOwner = viewLifecycleOwner
+
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        setLayout(view)
+        initEmoji()
+        initView()
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
+    private fun setLayout(view: View) {
+        requireNotNull(dialog).apply {
+            requireNotNull(window).apply {
+                setLayout(
+                    (resources.displayMetrics.widthPixels * 0.78).toInt(),
+                    ViewGroup.LayoutParams.WRAP_CONTENT
+                )
+                setBackgroundDrawableResource(bg_rect_white_r18)
+            }
+        }
+    }
+
+    private fun initEmoji() {
+        when (dialogMode) {
+            DELETE_HABIT_NO_HISTORY, DELETE_HABIT_WITH_HISTORY, DELETE_HABIT_WITH_MATE -> {
+                binding.tvEmoji.run {
+                    text = TRASH_EMOJI.toEmoji
+                    visible()
+                }
+            }
+            CANCEL_HABIT_CREATE, CANCEL_HABIT_MODIFY -> {
+                binding.tvEmoji.gone()
+            }
+        }
+    }
+
+    private fun initView() {
+        binding.tvTitle.run {
+            text = when (dialogMode) {
+                DELETE_HABIT_NO_HISTORY -> getString(R.string.title_delete_habit)
+                DELETE_HABIT_WITH_HISTORY -> getString(R.string.title_delete_habit)
+                DELETE_HABIT_WITH_MATE -> getString(R.string.title_delete_habit_with_mate)
+                CANCEL_HABIT_CREATE -> getString(R.string.title_cancel_habit_create)
+                CANCEL_HABIT_MODIFY -> getString(R.string.title_cancel_habit_modify)
+                else -> throw IllegalStateException()
+            }
+            margin(top = when(dialogMode) {
+                DELETE_HABIT_NO_HISTORY, DELETE_HABIT_WITH_HISTORY, DELETE_HABIT_WITH_MATE -> 30F
+                CANCEL_HABIT_CREATE, CANCEL_HABIT_MODIFY -> 28F
+                else -> throw IllegalStateException()
+            })
+        }
+        binding.tvDescription.run {
+            text = when (dialogMode) {
+                DELETE_HABIT_WITH_HISTORY -> getString(R.string.description_delete_habit_with_history)
+                DELETE_HABIT_WITH_MATE -> getString(R.string.description_delete_habit_with_mate)
+                CANCEL_HABIT_CREATE -> getString(R.string.description_cancel_habit_create)
+                CANCEL_HABIT_MODIFY -> getString(R.string.description_cancel_habit_modify)
+                else -> throw IllegalStateException()
+            }
+            visibleOrGone(dialogMode != DELETE_HABIT_NO_HISTORY)
+        }
+
+        binding.tvConfirm.run {
+            text = when (dialogMode) {
+                DELETE_HABIT_NO_HISTORY -> getString(R.string.reply_delete)
+                DELETE_HABIT_WITH_HISTORY -> getString(R.string.reply_delete)
+                DELETE_HABIT_WITH_MATE -> getString(R.string.reply_delete)
+                CANCEL_HABIT_CREATE -> getString(R.string.reply_cancel)
+                CANCEL_HABIT_MODIFY -> getString(R.string.reply_cancel)
+                else -> throw IllegalStateException()
+            }
+            setOnSingleClickListener{
+                onPositiveAction()
+                dismiss()
+            }
+        }
+
+        binding.tvCancel.run {
+            margin(top = when(dialogMode) {
+                DELETE_HABIT_NO_HISTORY, DELETE_HABIT_WITH_HISTORY, DELETE_HABIT_WITH_MATE -> 30F
+                CANCEL_HABIT_CREATE, CANCEL_HABIT_MODIFY -> 20F
+                else -> throw IllegalStateException()
+            })
+            setOnSingleClickListener {
+                dismiss()
+            }
+        }
+    }
+
+    companion object {
+        const val TAG = "ThreeDaysDialogFragment"
+
+        const val NOT_INIT = -1
+        const val DELETE_HABIT_NO_HISTORY = 0
+        const val DELETE_HABIT_WITH_HISTORY = 1
+        const val DELETE_HABIT_WITH_MATE = 2
+        const val CANCEL_HABIT_CREATE = 3
+        const val CANCEL_HABIT_MODIFY = 4
+
+        const val TRASH_EMOJI = 0x1F5D1
+
+        fun newInstance(dialogMode: Int, onPositiveAction: () -> Unit): ThreeDaysDialogFragment {
+            val fragment = ThreeDaysDialogFragment()
+            fragment.dialogMode = dialogMode
+            fragment.onPositiveAction = onPositiveAction
+            return fragment
+        }
+    }
+}

--- a/core/src/main/java/com/depromeet/threedays/core/util/ThreeDaysToast.kt
+++ b/core/src/main/java/com/depromeet/threedays/core/util/ThreeDaysToast.kt
@@ -7,18 +7,20 @@ import android.widget.TextView
 import android.widget.Toast
 import com.depromeet.threedays.core.R
 
-class CustomToast {
-    fun showTextToast(
+class ThreeDaysToast {
+    fun show(
         context: Context,
         title: String,
+        duration: Int = Toast.LENGTH_SHORT
     ) {
         val inflater = LayoutInflater.from(context)
         val toast = Toast(context)
-        val view = inflater.inflate(R.layout.toast_text, null)
+        val view = inflater.inflate(R.layout.toast_three_days, null)
         val textView: TextView = view.findViewById(R.id.tv_toast)
         textView.text = title
         toast.setGravity(Gravity.BOTTOM or Gravity.FILL_HORIZONTAL, 0, 0)
         toast.view = view
+        toast.duration = duration
         toast.show()
     }
 }

--- a/core/src/main/res/layout/fragment_three_days_dialog.xml
+++ b/core/src/main/res/layout/fragment_three_days_dialog.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="284dp"
+        android:layout_height="wrap_content"
+        tools:context=".util.ThreeDaysDialogFragment"
+        tools:ignore="ContentDescription">
+
+        <TextView
+            android:id="@+id/tv_emoji"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="40dp"
+            android:textSize="54sp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/tv_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="30dp"
+            android:gravity="center"
+            android:textAppearance="@style/Typography.Title1"
+            android:textColor="@color/gray_700"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/tv_emoji"
+            tools:text="작성중인 내용이 있어요\n나가시겠어요?" />
+
+        <TextView
+            android:id="@+id/tv_description"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:gravity="center"
+            android:textAppearance="@style/Typography.Paragraph2.14dp"
+            android:textColor="@color/gray_600"
+            app:layout_constraintEnd_toEndOf="@+id/tv_title"
+            app:layout_constraintStart_toStartOf="@+id/tv_title"
+            app:layout_constraintTop_toBottomOf="@+id/tv_title"
+            tools:text="지금까지 작성한 내용이 사라져요." />
+
+        <TextView
+            android:id="@+id/tv_cancel"
+            android:layout_width="0dp"
+            android:layout_height="43dp"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="20dp"
+            android:layout_marginEnd="4dp"
+            android:layout_marginBottom="16dp"
+            android:background="@drawable/bg_rect_gray200_r10"
+            android:gravity="center"
+            android:text="@string/reply_no"
+            android:textAppearance="@style/Typography.Button3"
+            android:textColor="@color/gray_600"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@+id/tv_confirm"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/tv_description" />
+
+        <TextView
+            android:id="@+id/tv_confirm"
+            android:layout_width="0dp"
+            android:layout_height="43dp"
+            android:layout_marginStart="4dp"
+            android:layout_marginEnd="16dp"
+            android:background="@drawable/bg_rect_main_r10"
+            android:gravity="center"
+            android:text="@string/reply_cancel"
+            android:textAppearance="@style/Typography.Button3"
+            android:textColor="@color/white"
+            app:layout_constraintBottom_toBottomOf="@+id/tv_cancel"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@id/tv_cancel"
+            app:layout_constraintTop_toTopOf="@+id/tv_cancel" />
+
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/core/src/main/res/layout/fragment_three_days_dialog.xml
+++ b/core/src/main/res/layout/fragment_three_days_dialog.xml
@@ -73,7 +73,7 @@
             android:layout_height="43dp"
             android:layout_marginStart="4dp"
             android:layout_marginEnd="16dp"
-            android:background="@drawable/bg_rect_main_r10"
+            android:background="@drawable/bg_rect_gray800_r10"
             android:gravity="center"
             android:text="@string/reply_cancel"
             android:textAppearance="@style/Typography.Button3"

--- a/core/src/main/res/layout/toast_three_days.xml
+++ b/core/src/main/res/layout/toast_three_days.xml
@@ -10,9 +10,9 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:background="@drawable/bg_rect_gray700_r10"
         android:layout_marginHorizontal="20dp"
         android:layout_marginBottom="75dp"
-        android:background="@drawable/bg_rect_toast_r5"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintBottom_toBottomOf="parent">
@@ -21,24 +21,24 @@
             android:id="@+id/iv_check"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginStart="15dp"
+            android:layout_marginStart="17dp"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
-            app:srcCompat="@drawable/ic_check" />
+            app:srcCompat="@drawable/ic_check_green" />
 
         <TextView
             android:id="@+id/tv_toast"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginVertical="8dp"
-            android:layout_marginStart="10dp"
-            android:textAppearance="@font/suit_medium"
-            android:textColor="@color/white"
+            android:layout_marginVertical="12dp"
+            android:layout_marginStart="9dp"
+            android:textAppearance="@style/Typography.Paragraph3.13dp"
+            android:textColor="@color/gray_200"
             android:textSize="14sp"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintStart_toEndOf="@+id/iv_check"
             app:layout_constraintTop_toTopOf="parent"
-            tools:text="짝심목표가 수정되었어요" />
+            tools:text="습관이 삭제됐어요." />
     </androidx.constraintlayout.widget.ConstraintLayout>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/core/src/main/res/values/ids.xml
+++ b/core/src/main/res/values/ids.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <item name="last_click_at" type="id" />
+</resources>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -1,0 +1,14 @@
+<resources>
+    <!-- dialog -->
+    <string name="title_delete_habit">습관을 삭제하시겠어요?</string>
+    <string name="title_delete_habit_with_mate">짝꿍과 연결된 습관이예요.\n삭제하시겠어요?</string>
+    <string name="title_cancel_habit_create">작성중인 내용이 있어요\n나가시겠어요?</string>
+    <string name="title_cancel_habit_modify">수정중인 내용이 있어요\n나가시겠어요?</string>
+    <string name="description_delete_habit_with_history">실천 기록이 있는 습관은 삭제 후\n보관함으로 이동돼요.</string>
+    <string name="description_delete_habit_with_mate">삭제된 습관과 짝꿍은 보관함에서\n확인할 수 있어요.</string>
+    <string name="description_cancel_habit_create">지금까지 작성한 내용이 사라져요.</string>
+    <string name="description_cancel_habit_modify">지금까지 수정한 내용이 사라져요.</string>
+    <string name="reply_no">아니요</string>
+    <string name="reply_delete">삭제할래요</string>
+    <string name="reply_cancel">나갈래요</string>
+</resources>

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -26,7 +26,8 @@ ext {
             "leakcanary"            : "2.9.1",
             "chucker"               : "3.5.2",
             "google"                : "20.2.0",
-            "room"                  : "2.4.3"
+            "room"                  : "2.4.3",
+            "emoji"                 : "1.0.0-alpha03"
     ]
     deps = [
             "kotlin"          : [
@@ -97,12 +98,16 @@ ext {
                     "kakao"                : "com.kakao.sdk:v2-user:${versions.kakao}",
                     "google"               : "com.google.android.gms:play-services-auth:${versions.google}"
             ],
-            "room": [
-                    "roomCommon"          : "androidx.room:room-common:${versions.room}",
-                    "roomCompiler"        : "androidx.room:room-compiler:${versions.room}",
-                    "roomKtx"             : "androidx.room:room-ktx:${versions.room}",
-                    "roomRuntime"         : "androidx.room:room-runtime:${versions.room}",
-                    "roomRxjava2"         : "androidx.room:room-rxjava2:${versions.room}"
+            "room"                         : [
+                    "roomCommon"           : "androidx.room:room-common:${versions.room}",
+                    "roomCompiler"         : "androidx.room:room-compiler:${versions.room}",
+                    "roomKtx"              : "androidx.room:room-ktx:${versions.room}",
+                    "roomRuntime"          : "androidx.room:room-runtime:${versions.room}",
+                    "roomRxjava2"          : "androidx.room:room-rxjava2:${versions.room}"
+            ],
+            "emoji"                        : [
+                    "emoji2"               : "androidx.emoji2:emoji2:${versions.emoji}",
+                    "emoji2View"           : "androidx.emoji2:emoji2-views:${versions.emoji}"
             ]
     ]
 
@@ -156,5 +161,10 @@ ext {
             deps.room.roomKtx,
             deps.room.roomRuntime,
             deps.room.roomRxjava2
+    ]
+
+    emojiDeps = [
+            deps.emoji.emoji2,
+            deps.emoji.emoji2View
     ]
 }

--- a/presentation/history/src/main/res/layout/item_objective.xml
+++ b/presentation/history/src/main/res/layout/item_objective.xml
@@ -5,7 +5,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:paddingHorizontal="20dp"
     android:paddingVertical="16dp"
-    android:background="@drawable/bg_rect_white_r10">
+    android:background="@drawable/bg_rect_white_r18">
 
     <TextView
         android:id="@+id/tv_object_emoji"

--- a/presentation/home/src/main/java/com/depromeet/threedays/home/home/HomeFragment.kt
+++ b/presentation/home/src/main/java/com/depromeet/threedays/home/home/HomeFragment.kt
@@ -11,7 +11,7 @@ import androidx.lifecycle.repeatOnLifecycle
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.depromeet.threedays.core.BaseFragment
-import com.depromeet.threedays.core.util.CustomToast
+import com.depromeet.threedays.core.util.ThreeDaysToast
 import com.depromeet.threedays.core.util.dpToPx
 import com.depromeet.threedays.domain.entity.habit.Habit
 import com.depromeet.threedays.domain.key.RESULT_CREATE
@@ -43,7 +43,7 @@ class HomeFragment : BaseFragment<FragmentHomeBinding, HomeViewModel>(R.layout.f
             RESULT_CREATE -> viewModel.fetchGoals()
             RESULT_MODIFY -> {
                 viewModel.fetchGoals()
-                CustomToast().showTextToast(
+                ThreeDaysToast().show(
                     requireContext(),
                     resources.getString(R.string.three_day_goal_modify_toast)
                 )


### PR DESCRIPTION
## 💁‍♂️ 변경 내용
### AS-IS
- dialog util이 없었습니다
- toast가 UT 기준 디자인이었습니다

### TO-BE
- dialog를 손쉽게 띄울 수 있습니다
- toast의 디자인이 변경되고, 띄우는 시간을 (duration)을 설정할 수 있게 수정했습니다

## 📢 전달사항
dialog는 flag, 확인 버튼 눌렀을 때의 action을 전달하도록 했고
toast는 text를 전달하도록 했습니다.
dialog에서 title, description, emoji 등의 정보를 다 전달하지 않도록 한 이유는 정보양이 많은 것 같아서였는데,,, dialog가 계속 늘어난다면 데이터를 전달하는 방식으로 바꾸는게 좋은가? 고민이네요 (만약 같은 dialog를 여러 시점에서 호출한다면 지금의 방식이 더 편할 것 같긴합니다)

- DELETE_HABIT_NO_HISTORY
![image](https://user-images.githubusercontent.com/68214704/203593738-b66211de-43c4-47c6-9ca1-df18f2627b7c.png)

- DELETE_HABIT_WITH_HISTORY
![image](https://user-images.githubusercontent.com/68214704/203593889-389aadf3-3d5d-4462-8b95-1135c50fff84.png)

- DELETE_HABIT_WITH_MATE
![image](https://user-images.githubusercontent.com/68214704/203594175-4041d9ba-a1b5-4ed9-9497-38c4e65c0bd0.png)

- CANCEL_HABIT_CREATE
![image](https://user-images.githubusercontent.com/68214704/203594289-a9330bcf-0289-4034-9a3f-ca81c072765c.png)

- CANCEL_HABIT_MODIFY
![image](https://user-images.githubusercontent.com/68214704/203594393-bb5ba58e-0386-4ebd-a88c-ff7203c0962c.png)


- 다이얼로그 사용법
```
ThreeDaysDialogFragment.newInstance(
            dialogMode = 위의 값들 중 하나,
            onPositiveAction = 우측버튼 눌렀을 때 벌어질 행동에 대한 함수
        ).show(프래그먼트매니저(supportFragmentManager, childFragmentManager,..), ThreeDaysDialogFragment.TAG)
```

- 토스트 사용법
```
ThreeDaysToast().show(context, 표시할 문구)
```

! 스낵바는 아직 한 곳 밖에 안쓰여서 일단 안 만들긴했는데,, 차차 제작해보겠습니닷
(스낵바를 아직 써본적이 없어서 얼마나 걸릴질? 모르겠어서 우선 완성한데까지라도 머지하자! 라는 심정에서 먼저 올립니닷)