### PR TITLE
DEP-148 ui: 나의 기록 ui 변경 사항 적용

### DIFF
--- a/core-design-system/src/main/res/drawable/ic_check_small.xml
+++ b/core-design-system/src/main/res/drawable/ic_check_small.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="25dp"
+    android:height="24dp"
+    android:viewportWidth="25"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M12.5,12m-11,0a11,11 0,1 1,22 0a11,11 0,1 1,-22 0"
+      android:fillColor="#ffffff"/>
+  <path
+      android:pathData="M11.594,15.365C11.4,15.365 11.206,15.3 11.076,15.106L8.1,12.129C7.776,11.806 7.776,11.353 8.1,11.029C8.423,10.706 8.876,10.706 9.2,11.029L11.594,13.423L15.865,9.153C16.188,8.829 16.641,8.829 16.965,9.153C17.288,9.476 17.288,9.929 16.965,10.253L12.176,15.041C11.982,15.3 11.788,15.365 11.594,15.365Z"
+      android:fillColor="#353C49"/>
+</vector>

--- a/presentation/history/src/main/res/layout/fragment_history.xml
+++ b/presentation/history/src/main/res/layout/fragment_history.xml
@@ -26,6 +26,12 @@
             android:orientation="vertical"
             app:layout_constraintGuide_end="20dp" />
 
+        <androidx.constraintlayout.widget.Group
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:visibility="visible"
+            app:constraint_referenced_ids="tv_illustration, tv_no_habit_guide, btn_create_habit" />
+
         <ImageView
             android:id="@+id/iv_prev_month"
             android:layout_width="24dp"
@@ -88,191 +94,200 @@
             android:layout_height="35dp"
             app:layout_constraintTop_toBottomOf="@+id/tv_this_month"/>
 
-        <androidx.constraintlayout.widget.Group
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:visibility="gone"
-            app:constraint_referenced_ids="cl_this_month_clap, cl_this_month_achieve_days, cl_most_achieve, tv_ongoing_habit, rv_habit" />
-
-        <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/cl_this_month_clap"
-            android:layout_width="0dp"
-            android:layout_height="100dp"
-            android:background="@drawable/bg_rect_gray700_r10"
-            app:layout_constraintEnd_toStartOf="@id/gl_middle"
-            app:layout_constraintStart_toStartOf="@id/gl_begin"
-            app:layout_constraintTop_toBottomOf="@+id/space_bottom_of_toolbar">
-
-            <TextView
-                android:id="@+id/tv_this_month_clap_title"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="18dp"
-                android:textAppearance="@style/Typography.Body3"
-                android:textColor="@color/gray_300"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
-                tools:text="@string/this_month_clap_title"/>
-
-            <TextView
-                android:id="@+id/tv_clap_emoji"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/clap"
-                android:textAppearance="@style/Typography.Heading"
-                android:textColor="@color/white"
-                app:layout_constraintBottom_toBottomOf="@+id/tv_this_month_clap"
-                app:layout_constraintEnd_toStartOf="@+id/tv_this_month_clap"
-                app:layout_constraintHorizontal_bias="0.5"
-                app:layout_constraintHorizontal_chainStyle="packed"
-                app:layout_constraintStart_toStartOf="parent" />
-
-            <TextView
-                android:id="@+id/tv_this_month_clap"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginBottom="24dp"
-                android:layout_marginStart="8dp"
-                android:textAppearance="@style/Typography.Heading"
-                android:textColor="@color/white"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintHorizontal_bias="0.5"
-                app:layout_constraintStart_toEndOf="@+id/tv_clap_emoji"
-                tools:text="4"/>
-        </androidx.constraintlayout.widget.ConstraintLayout>
-
-        <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/cl_this_month_achieve_days"
-            android:layout_width="0dp"
-            android:layout_height="100dp"
-            android:layout_marginTop="12dp"
-            android:background="@drawable/bg_rect_gray700_r10"
-            app:layout_constraintStart_toStartOf="@id/gl_begin"
-            app:layout_constraintEnd_toStartOf="@id/gl_middle"
-            app:layout_constraintTop_toBottomOf="@+id/cl_this_month_clap">
-
-            <TextView
-                android:id="@+id/tv_this_month_achieve_days_title"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="18dp"
-                android:textAppearance="@style/Typography.Body3"
-                android:textColor="@color/gray_300"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
-                tools:text="@string/this_month_achieve_days_title"/>
-
-            <TextView
-                android:id="@+id/tv_watch_emoji"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/watch"
-                android:textAppearance="@style/Typography.Heading"
-                android:textColor="@color/white"
-                app:layout_constraintBottom_toBottomOf="@+id/tv_this_month_achieve_days"
-                app:layout_constraintEnd_toStartOf="@+id/tv_this_month_achieve_days"
-                app:layout_constraintHorizontal_bias="0.5"
-                app:layout_constraintHorizontal_chainStyle="packed"
-                app:layout_constraintStart_toStartOf="parent" />
-
-            <TextView
-                android:id="@+id/tv_this_month_achieve_days"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginBottom="24dp"
-                android:layout_marginStart="8dp"
-                android:textAppearance="@style/Typography.Heading"
-                android:textColor="@color/white"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintHorizontal_bias="0.5"
-                app:layout_constraintStart_toEndOf="@+id/tv_watch_emoji"
-                tools:text="26" />
-        </androidx.constraintlayout.widget.ConstraintLayout>
-
-        <Space
-            android:id="@+id/gl_middle"
-            android:layout_width="12dp"
-            android:layout_height="match_parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent" />
-
-        <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/cl_most_achieve"
-            android:layout_width="0dp"
-            android:layout_height="212dp"
-            android:background="@drawable/bg_rect_green50_r10"
-            app:layout_constraintEnd_toEndOf="@id/gl_end"
-            app:layout_constraintStart_toEndOf="@+id/gl_middle"
-            app:layout_constraintTop_toTopOf="@+id/cl_this_month_clap">
-
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="17dp"
-                android:gravity="center"
-                android:text="@string/this_month_most_achieve_habit_guide"
-                android:textAppearance="@style/Typography.Paragraph3.13dp"
-                android:textColor="@color/white"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
-
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/medicine"
-                android:textAppearance="@style/Typography.Body1"
-                android:textSize="48sp"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
-                app:layout_constraintBottom_toBottomOf="parent"/>
-
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginBottom="15dp"
-                android:gravity="center"
-                android:textAppearance="@style/Typography.Body2"
-                android:textColor="#FDFDFD"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintBottom_toBottomOf="parent"
-                tools:text="@string/this_month_most_achieve_habit_title"/>
-        </androidx.constraintlayout.widget.ConstraintLayout>
-
-        <TextView
-            android:id="@+id/tv_ongoing_habit"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="36dp"
-            android:text="@string/ongoing_habit"
-            android:textAppearance="@style/Typography.Body2"
-            android:textColor="@color/gray_500"
-            app:layout_constraintStart_toStartOf="@id/gl_begin"
-            app:layout_constraintTop_toBottomOf="@+id/cl_this_month_achieve_days" />
-
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/rv_habit"
+        <androidx.core.widget.NestedScrollView
+            android:id="@+id/ncv_has_habit"
             android:layout_width="0dp"
             android:layout_height="0dp"
-            android:layout_marginTop="12dp"
+            android:visibility="gone"
+            android:fillViewport="true"
+            app:layout_constraintTop_toBottomOf="@+id/space_bottom_of_toolbar"
             app:layout_constraintStart_toStartOf="@id/gl_begin"
             app:layout_constraintEnd_toEndOf="@id/gl_end"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/tv_ongoing_habit"
-            tools:listitem="@layout/item_habit"/>
+            app:layout_constraintBottom_toBottomOf="parent">
 
-        <androidx.constraintlayout.widget.Group
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:visibility="visible"
-            app:constraint_referenced_ids="tv_illustration, tv_no_habit_guide, btn_create_habit" />
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" >
 
+                <androidx.constraintlayout.widget.ConstraintLayout
+                    android:id="@+id/cl_this_month_clap"
+                    android:layout_width="0dp"
+                    android:layout_height="100dp"
+                    android:background="@drawable/bg_rect_gray700_r10"
+                    app:layout_constraintEnd_toStartOf="@id/gl_middle"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent">
+
+                    <TextView
+                        android:id="@+id/tv_this_month_clap_title"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="18dp"
+                        android:textAppearance="@style/Typography.Body3"
+                        android:textColor="@color/gray_300"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="parent"
+                        tools:text="@string/this_month_clap_title"/>
+
+                    <TextView
+                        android:id="@+id/tv_clap_emoji"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/clap"
+                        android:textAppearance="@style/Typography.Heading"
+                        android:textColor="@color/white"
+                        app:layout_constraintBottom_toBottomOf="@+id/tv_this_month_clap"
+                        app:layout_constraintEnd_toStartOf="@+id/tv_this_month_clap"
+                        app:layout_constraintHorizontal_bias="0.5"
+                        app:layout_constraintHorizontal_chainStyle="packed"
+                        app:layout_constraintStart_toStartOf="parent" />
+
+                    <TextView
+                        android:id="@+id/tv_this_month_clap"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginBottom="24dp"
+                        android:layout_marginStart="8dp"
+                        android:textAppearance="@style/Typography.Heading"
+                        android:textColor="@color/white"
+                        app:layout_constraintBottom_toBottomOf="parent"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintHorizontal_bias="0.5"
+                        app:layout_constraintStart_toEndOf="@+id/tv_clap_emoji"
+                        tools:text="4"/>
+                </androidx.constraintlayout.widget.ConstraintLayout>
+
+                <androidx.constraintlayout.widget.ConstraintLayout
+                    android:id="@+id/cl_this_month_achieve_days"
+                    android:layout_width="0dp"
+                    android:layout_height="100dp"
+                    android:layout_marginTop="12dp"
+                    android:background="@drawable/bg_rect_gray700_r10"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintEnd_toStartOf="@id/gl_middle"
+                    app:layout_constraintTop_toBottomOf="@+id/cl_this_month_clap">
+
+                    <TextView
+                        android:id="@+id/tv_this_month_achieve_days_title"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="18dp"
+                        android:textAppearance="@style/Typography.Body3"
+                        android:textColor="@color/gray_300"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="parent"
+                        tools:text="@string/this_month_achieve_days_title"/>
+
+                    <TextView
+                        android:id="@+id/tv_watch_emoji"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/watch"
+                        android:textAppearance="@style/Typography.Heading"
+                        android:textColor="@color/white"
+                        app:layout_constraintBottom_toBottomOf="@+id/tv_this_month_achieve_days"
+                        app:layout_constraintEnd_toStartOf="@+id/tv_this_month_achieve_days"
+                        app:layout_constraintHorizontal_bias="0.5"
+                        app:layout_constraintHorizontal_chainStyle="packed"
+                        app:layout_constraintStart_toStartOf="parent" />
+
+                    <TextView
+                        android:id="@+id/tv_this_month_achieve_days"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginBottom="24dp"
+                        android:layout_marginStart="8dp"
+                        android:textAppearance="@style/Typography.Heading"
+                        android:textColor="@color/white"
+                        app:layout_constraintBottom_toBottomOf="parent"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintHorizontal_bias="0.5"
+                        app:layout_constraintStart_toEndOf="@+id/tv_watch_emoji"
+                        tools:text="26" />
+                </androidx.constraintlayout.widget.ConstraintLayout>
+
+                <Space
+                    android:id="@+id/gl_middle"
+                    android:layout_width="12dp"
+                    android:layout_height="match_parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent" />
+
+                <androidx.constraintlayout.widget.ConstraintLayout
+                    android:id="@+id/cl_most_achieve"
+                    android:layout_width="0dp"
+                    android:layout_height="212dp"
+                    android:background="@drawable/bg_rect_green50_r10"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toEndOf="@+id/gl_middle"
+                    app:layout_constraintTop_toTopOf="@+id/cl_this_month_clap">
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="17dp"
+                        android:gravity="center"
+                        android:text="@string/this_month_most_achieve_habit_guide"
+                        android:textAppearance="@style/Typography.Paragraph3.13dp"
+                        android:textColor="@color/white"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="parent" />
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/medicine"
+                        android:textAppearance="@style/Typography.Body1"
+                        android:textSize="48sp"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="parent"
+                        app:layout_constraintBottom_toBottomOf="parent"/>
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginBottom="15dp"
+                        android:gravity="center"
+                        android:textAppearance="@style/Typography.Body2"
+                        android:textColor="#FDFDFD"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintBottom_toBottomOf="parent"
+                        tools:text="@string/this_month_most_achieve_habit_title"/>
+                </androidx.constraintlayout.widget.ConstraintLayout>
+
+                <TextView
+                    android:id="@+id/tv_ongoing_habit"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="36dp"
+                    android:text="@string/ongoing_habit"
+                    android:textAppearance="@style/Typography.Body2"
+                    android:textColor="@color/gray_500"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/cl_this_month_achieve_days" />
+
+                <androidx.recyclerview.widget.RecyclerView
+                    android:id="@+id/rv_habit"
+                    android:layout_width="0dp"
+                    android:layout_height="0dp"
+                    android:layout_marginTop="12dp"
+                    android:clipToPadding="false"
+                    android:paddingBottom="20dp"
+                    app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/tv_ongoing_habit"
+                    tools:listitem="@layout/item_habit"/>
+            </androidx.constraintlayout.widget.ConstraintLayout>
+        </androidx.core.widget.NestedScrollView>
+
+        <!-- 습관이 없을 때 보여줄 Views -->
         <TextView
             android:id="@+id/tv_illustration"
             android:layout_width="200dp"

--- a/presentation/history/src/main/res/layout/fragment_history.xml
+++ b/presentation/history/src/main/res/layout/fragment_history.xml
@@ -83,7 +83,7 @@
             android:background="@drawable/bg_rect_white_r10"
             android:textAppearance="@style/Typography.Paragraph3.13dp"
             android:text="@string/history_tooltip_guide"
-            android:elevation="8dp"
+            android:elevation="4dp"
             android:visibility="gone"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/iv_tooltip" />
@@ -130,18 +130,18 @@
                         app:layout_constraintTop_toTopOf="parent"
                         tools:text="@string/this_month_clap_title"/>
 
-                    <TextView
-                        android:id="@+id/tv_clap_emoji"
+                    <ImageView
+                        android:id="@+id/iv_clap"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="@string/clap"
-                        android:textAppearance="@style/Typography.Heading"
-                        android:textColor="@color/white"
+                        android:src="@drawable/ic_clap"
+                        app:tint="@color/white"
                         app:layout_constraintBottom_toBottomOf="@+id/tv_this_month_clap"
                         app:layout_constraintEnd_toStartOf="@+id/tv_this_month_clap"
                         app:layout_constraintHorizontal_bias="0.5"
                         app:layout_constraintHorizontal_chainStyle="packed"
-                        app:layout_constraintStart_toStartOf="parent" />
+                        app:layout_constraintStart_toStartOf="parent"
+                        tools:tint="@color/white"/>
 
                     <TextView
                         android:id="@+id/tv_this_month_clap"
@@ -154,7 +154,7 @@
                         app:layout_constraintBottom_toBottomOf="parent"
                         app:layout_constraintEnd_toEndOf="parent"
                         app:layout_constraintHorizontal_bias="0.5"
-                        app:layout_constraintStart_toEndOf="@+id/tv_clap_emoji"
+                        app:layout_constraintStart_toEndOf="@+id/iv_clap"
                         tools:text="4"/>
                 </androidx.constraintlayout.widget.ConstraintLayout>
 
@@ -180,13 +180,11 @@
                         app:layout_constraintTop_toTopOf="parent"
                         tools:text="@string/this_month_achieve_days_title"/>
 
-                    <TextView
-                        android:id="@+id/tv_watch_emoji"
+                    <ImageView
+                        android:id="@+id/iv_watch"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="@string/watch"
-                        android:textAppearance="@style/Typography.Heading"
-                        android:textColor="@color/white"
+                        android:src="@drawable/ic_check_small"
                         app:layout_constraintBottom_toBottomOf="@+id/tv_this_month_achieve_days"
                         app:layout_constraintEnd_toStartOf="@+id/tv_this_month_achieve_days"
                         app:layout_constraintHorizontal_bias="0.5"
@@ -204,7 +202,7 @@
                         app:layout_constraintBottom_toBottomOf="parent"
                         app:layout_constraintEnd_toEndOf="parent"
                         app:layout_constraintHorizontal_bias="0.5"
-                        app:layout_constraintStart_toEndOf="@+id/tv_watch_emoji"
+                        app:layout_constraintStart_toEndOf="@+id/iv_watch"
                         tools:text="26" />
                 </androidx.constraintlayout.widget.ConstraintLayout>
 
@@ -317,7 +315,7 @@
             android:id="@+id/btn_create_habit"
             android:layout_width="wrap_content"
             android:layout_height="48dp"
-            android:layout_marginTop="30dp"
+            android:layout_marginTop="24dp"
             android:background="@drawable/bg_rect_gray800_r30"
             android:gravity="center"
             android:paddingHorizontal="44dp"


### PR DESCRIPTION
## 💁‍♂️ 변경 내용
![20221213_011925](https://user-images.githubusercontent.com/76620764/207097644-98037037-6429-4d36-92b0-a7294a11caf2.png)

### AS-IS
- 스크롤 영역이 빨간색 박스 만큼으로 잡혀있었습니다.
- 이모지를 사용했습니다. (박수, 체크)

### TO-BE
- 스크롤 영역이 파란색 만큼으로 늘어났습니다.
  - NestedScrollView안에 기존 코드를 때려 넣었습니다. 변경된 코드가 많아 보이는 건 코드의 위치가 바뀌어서 그렇습니다.
- 이모지 대신 아이콘을 사용합니다. (박수, 체크)

그 외에 툴팁 쉐도우, 뷰 간의 margin 조정, 마지막 아이템 바닥과 20dp 띄우기가 적용됐습니다.