### PR TITLE
DEP-000 불필요한 빌드 로그 줄이기

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,4 +33,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: chmod +x ./gradlew && ./gradlew build sonarqube --info
+        run: chmod +x ./gradlew && ./gradlew --warn build sonarqube --info

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,6 @@
 name: Build
 on:
+  workflow_dispatch:
   push:
     branches:
       - develop

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,6 @@
 name: Deploy
 on:
+  workflow_dispatch:
   push:
     branches:
       - develop

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Build
+name: Deploy
 on:
   push:
     branches:
@@ -22,7 +22,7 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
           restore-keys: ${{ runner.os }}-gradle
       - name: Build
-        run: chmod +x ./gradlew && ./gradlew build
+        run: chmod +x ./gradlew && ./gradlew --quiet build
       - name: Fetch credential file from secrets
         id: fetch_credential_file
         uses: timheuer/base64-to-file@v1


### PR DESCRIPTION
## 💁‍♂️ 변경 내용
로그가 너무 많이 남아서 빌드 실패 원인을 확인하기 어려운 현상을 해결합니다. 
  - 로그가 약 13만줄 정도 남는데, 7만줄 이후는 웹페이지에서 확인이 안됨 (파일다운받아야함)
  - 내용이 많고 스크롤이 길어서 페이지가 느려짐

### AS-IS
- 로그 레벨 기본값 (lifecycle 이상)
- 수동으로 GitHub Action 트리거 못함
### TO-BE
- 로그 레벨 변경 (build 는 warn 이상, deploy 는 error 이상만 로그 남김)
- 수동으로 GitHub Action 트리거 할 수 있음
## 📢 전달사항
| option | logging level | file size |
|-|-|-|
| default | >= lifecycle | 114119 |
| --warn | >= warn | 18845 |
| --quiet | >= error | 1493 | 

- 로그 파일 크기 비교해보니 `--warn` 적용하면 1/10 정도, `--quiet` 적용하면 1/100 정도 줄어드는거 확인했습니다 
- https://docs.gradle.org/current/userguide/logging.html
- https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow
