### PR TITLE
DEP-246 feat: 닉네임 수정 API 연동

### DIFF
--- a/data/src/main/java/com/depromeet/threedays/data/api/MemberService.kt
+++ b/data/src/main/java/com/depromeet/threedays/data/api/MemberService.kt
@@ -2,9 +2,17 @@ package com.depromeet.threedays.data.api
 
 import com.depromeet.threedays.data.entity.base.ApiResponse
 import com.depromeet.threedays.data.entity.member.MemberEntity
+import com.depromeet.threedays.data.entity.member.UpdateNicknameRequest
+import retrofit2.http.Body
 import retrofit2.http.GET
+import retrofit2.http.PATCH
 
 interface MemberService {
     @GET("/api/v1/members/me")
     suspend fun getMyInfo(): ApiResponse<MemberEntity>
+
+    @PATCH("/api/v1/members/name")
+    suspend fun updateName(
+        @Body updateNicknameRequest: UpdateNicknameRequest
+    ): ApiResponse<MemberEntity>
 }

--- a/data/src/main/java/com/depromeet/threedays/data/datasource/member/MemberRemoteDataSource.kt
+++ b/data/src/main/java/com/depromeet/threedays/data/datasource/member/MemberRemoteDataSource.kt
@@ -4,4 +4,5 @@ import com.depromeet.threedays.data.entity.member.MemberEntity
 
 interface MemberRemoteDataSource {
     suspend fun getMyInfo(): MemberEntity
+    suspend fun updateNickname(nickname: String): MemberEntity
 }

--- a/data/src/main/java/com/depromeet/threedays/data/datasource/member/MemberRemoteDataSourceImpl.kt
+++ b/data/src/main/java/com/depromeet/threedays/data/datasource/member/MemberRemoteDataSourceImpl.kt
@@ -2,6 +2,7 @@ package com.depromeet.threedays.data.datasource.member
 
 import com.depromeet.threedays.data.api.MemberService
 import com.depromeet.threedays.data.entity.member.MemberEntity
+import com.depromeet.threedays.data.entity.member.UpdateNicknameRequest
 import javax.inject.Inject
 
 class MemberRemoteDataSourceImpl @Inject constructor(
@@ -9,5 +10,13 @@ class MemberRemoteDataSourceImpl @Inject constructor(
 ) : MemberRemoteDataSource {
     override suspend fun getMyInfo(): MemberEntity {
         return memberService.getMyInfo().data!!
+    }
+
+    override suspend fun updateNickname(nickname: String): MemberEntity {
+        return memberService.updateName(
+            updateNicknameRequest = UpdateNicknameRequest(
+                name = nickname,
+            ),
+        ).data!!
     }
 }

--- a/data/src/main/java/com/depromeet/threedays/data/entity/member/UpdateNicknameRequest.kt
+++ b/data/src/main/java/com/depromeet/threedays/data/entity/member/UpdateNicknameRequest.kt
@@ -1,0 +1,5 @@
+package com.depromeet.threedays.data.entity.member
+
+data class UpdateNicknameRequest(
+    val name: String,
+)

--- a/data/src/main/java/com/depromeet/threedays/data/repository/MemberRepositoryImpl.kt
+++ b/data/src/main/java/com/depromeet/threedays/data/repository/MemberRepositoryImpl.kt
@@ -26,4 +26,19 @@ class MemberRepositoryImpl @Inject constructor(
             }
         }
     }
+
+    override fun updateNickname(nickname: String): Flow<DataState<Member>> {
+        return flow {
+            emit(DataState.loading())
+            memberRemoteDataSource.updateNickname(nickname).apply {
+                emit(
+                    DataState.success(
+                        data = this.toMember()
+                    )
+                )
+            }.runCatching {
+                emit(DataState.fail("Failed to get response"))
+            }
+        }
+    }
 }

--- a/domain/src/main/java/com/depromeet/threedays/domain/repository/MemberRepository.kt
+++ b/domain/src/main/java/com/depromeet/threedays/domain/repository/MemberRepository.kt
@@ -6,4 +6,5 @@ import kotlinx.coroutines.flow.Flow
 
 interface MemberRepository {
     fun getMyInfo(): Flow<DataState<Member>>
+    fun updateNickname(nickname: String): Flow<DataState<Member>>
 }

--- a/domain/src/main/java/com/depromeet/threedays/domain/usecase/member/UpdateNicknameUseCase.kt
+++ b/domain/src/main/java/com/depromeet/threedays/domain/usecase/member/UpdateNicknameUseCase.kt
@@ -1,0 +1,15 @@
+package com.depromeet.threedays.domain.usecase.member
+
+import com.depromeet.threedays.domain.entity.DataState
+import com.depromeet.threedays.domain.entity.member.Member
+import com.depromeet.threedays.domain.repository.MemberRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class UpdateNicknameUseCase @Inject constructor(
+    private val memberRepository: MemberRepository,
+) {
+    operator fun invoke(nickname: String): Flow<DataState<Member>> {
+        return memberRepository.updateNickname(nickname = nickname)
+    }
+}

--- a/presentation/mypage/src/main/java/com/depromeet/threedays/mypage/MyPageFragment.kt
+++ b/presentation/mypage/src/main/java/com/depromeet/threedays/mypage/MyPageFragment.kt
@@ -81,7 +81,10 @@ class MyPageFragment :
         val nickname = binding.tvNickname.text.toString()
         EditNicknameDialogFragment(
             nickname = nickname,
-            onSubmit = { ThreeDaysToast().show(requireContext(), "닉네임이 변경됐어요.") },
+            onSubmit = {
+                viewModel.updateNickname(nickname = it)
+                ThreeDaysToast().show(requireContext(), "닉네임이 변경됐어요.")
+            },
         ).show(
             requireActivity().supportFragmentManager,
             EditNicknameDialogFragment.TAG,

--- a/presentation/mypage/src/main/java/com/depromeet/threedays/mypage/MyPageViewModel.kt
+++ b/presentation/mypage/src/main/java/com/depromeet/threedays/mypage/MyPageViewModel.kt
@@ -5,6 +5,7 @@ import com.depromeet.threedays.core.BaseViewModel
 import com.depromeet.threedays.core.extensions.Empty
 import com.depromeet.threedays.domain.entity.Status
 import com.depromeet.threedays.domain.usecase.member.GetMyInfoUseCase
+import com.depromeet.threedays.domain.usecase.member.UpdateNicknameUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -14,6 +15,7 @@ import javax.inject.Inject
 @HiltViewModel
 class MyPageViewModel @Inject constructor(
     private val getMyInfoUseCase: GetMyInfoUseCase,
+    private val updateNicknameUseCase: UpdateNicknameUseCase,
 ) : BaseViewModel() {
     private val _nickname: MutableStateFlow<String> = MutableStateFlow(String.Empty)
     val nickname: StateFlow<String>
@@ -25,6 +27,26 @@ class MyPageViewModel @Inject constructor(
     fun fetchMyInfo() {
         viewModelScope.launch {
             getMyInfoUseCase().collect { response ->
+                when (response.status) {
+                    Status.LOADING -> {
+                        // Do nothing
+                    }
+                    Status.SUCCESS -> {
+                        _nickname.value = response.data!!.name
+                    }
+                    Status.ERROR -> TODO()
+                    Status.FAIL -> TODO()
+                }
+            }
+        }
+    }
+
+    /**
+     * 닉네임 수정
+     */
+    fun updateNickname(nickname: String) {
+        viewModelScope.launch {
+            updateNicknameUseCase(nickname = nickname).collect { response ->
                 when (response.status) {
                     Status.LOADING -> {
                         // Do nothing

--- a/presentation/mypage/src/main/java/com/depromeet/threedays/mypage/nickname/EditNicknameDialogFragment.kt
+++ b/presentation/mypage/src/main/java/com/depromeet/threedays/mypage/nickname/EditNicknameDialogFragment.kt
@@ -8,13 +8,13 @@ import androidx.core.widget.doAfterTextChanged
 import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.DialogFragment
 import com.depromeet.threedays.mypage.R
-import com.depromeet.threedays.core_design_system.R as CoreDesignSystemResources
 import com.depromeet.threedays.mypage.databinding.FragmentEditNicknameDialogBinding
+import com.depromeet.threedays.core_design_system.R as CoreDesignSystemResources
 
-
+// FIXME: 다이얼로그 나오면 키보드 자동으로 띄우기
 class EditNicknameDialogFragment(
     val nickname: String,
-    val onSubmit: () -> Unit,
+    val onSubmit: (String) -> Unit,
 ) : DialogFragment() {
     private var _binding: FragmentEditNicknameDialogBinding? = null
     private val binding get() = _binding!!
@@ -23,7 +23,12 @@ class EditNicknameDialogFragment(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        _binding = DataBindingUtil.inflate(inflater, R.layout.fragment_edit_nickname_dialog, container, false)
+        _binding = DataBindingUtil.inflate(
+            inflater,
+            R.layout.fragment_edit_nickname_dialog,
+            container,
+            false
+        )
         binding.lifecycleOwner = viewLifecycleOwner
         return binding.root
     }
@@ -51,7 +56,6 @@ class EditNicknameDialogFragment(
     private fun initView() {
         binding.etNickname.apply {
             setText(nickname)
-
         }
 //            requestFocus()
 //            val inputMethodManager = getSystemService(context, InputMethodManager::class.java)
@@ -63,7 +67,8 @@ class EditNicknameDialogFragment(
             dismiss()
         }
         binding.tvSubmit.setOnClickListener {
-            onSubmit()
+            val updatedNickname = binding.etNickname.text.toString()
+            onSubmit(updatedNickname)
             dismiss()
         }
 


### PR DESCRIPTION
## 💁‍♂️ 변경 내용
### AS-IS
- 하드코딩된 닉네임 값을 사용했습니다. 
### TO-BE
- 닉네임 수정 후 저장 버튼 누르면 `PATCH /api/v1/members/name` API 호출합니다

## 📢 전달사항
- loading, error 는 처리하지 않았습니다