### PR TITLE
DEP-254 feat: 알림내역 읽음처리 API 연동

### DIFF
--- a/core/src/main/java/com/depromeet/threedays/core/extensions/LocalDateTime.kt
+++ b/core/src/main/java/com/depromeet/threedays/core/extensions/LocalDateTime.kt
@@ -1,0 +1,17 @@
+package com.depromeet.threedays.core.extensions
+
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
+/**
+ * 현재 시각과 비교해서 날짜가 같으면 시분, 다르면 연월일로 표시한다
+ */
+fun LocalDateTime.formatRelatively(now: LocalDateTime): String {
+    return format(
+        if (this.toLocalDate() == now.toLocalDate()) {
+            DateTimeFormatter.ofPattern("HH:mm")
+        } else {
+            DateTimeFormatter.ofPattern("yyyy.MM.dd")
+        }
+    )
+}

--- a/data/src/main/java/com/depromeet/threedays/data/api/NotificationHistoryService.kt
+++ b/data/src/main/java/com/depromeet/threedays/data/api/NotificationHistoryService.kt
@@ -1,10 +1,26 @@
 package com.depromeet.threedays.data.api
 
+import com.depromeet.threedays.data.entity.notification.NotificationHistoryReadRequest
 import com.depromeet.threedays.data.entity.base.ApiResponse
 import com.depromeet.threedays.data.entity.notification.NotificationHistoryEntity
+import retrofit2.http.Body
 import retrofit2.http.GET
+import retrofit2.http.PATCH
+import retrofit2.http.Path
 
 interface NotificationHistoryService {
+    /**
+     * 알림 이력 목록 조회
+     */
     @GET("/api/v1/notifications")
     suspend fun getNotificationHistories(): ApiResponse<List<NotificationHistoryEntity>>
+
+    /**
+     * 알림 이력 읽음 처리
+     */
+    @PATCH("/api/v1/notifications/{notificationId}")
+    suspend fun updateStatus(
+        @Path("notificationId") notificationHistoryId: Long,
+        @Body notificationHistoryReadRequest: NotificationHistoryReadRequest,
+    ): ApiResponse<NotificationHistoryEntity>
 }

--- a/data/src/main/java/com/depromeet/threedays/data/datasource/notification/NotificationHistoryRemoteDataSource.kt
+++ b/data/src/main/java/com/depromeet/threedays/data/datasource/notification/NotificationHistoryRemoteDataSource.kt
@@ -1,8 +1,12 @@
 package com.depromeet.threedays.data.datasource.notification
 
 import com.depromeet.threedays.data.entity.notification.NotificationHistoryEntity
+import com.depromeet.threedays.domain.entity.notification.NotificationHistoryStatus
 
 interface NotificationHistoryRemoteDataSource {
-    suspend fun setNotificationAsRead(notificationHistoryEntity: NotificationHistoryEntity)
     suspend fun getNotificationHistories(): List<NotificationHistoryEntity>
+    suspend fun updateStatus(
+        notificationHistoryId: Long,
+        notificationHistoryStatus: NotificationHistoryStatus,
+    ): NotificationHistoryEntity
 }

--- a/data/src/main/java/com/depromeet/threedays/data/datasource/notification/NotificationHistoryRemoteDataSourceImpl.kt
+++ b/data/src/main/java/com/depromeet/threedays/data/datasource/notification/NotificationHistoryRemoteDataSourceImpl.kt
@@ -2,16 +2,26 @@ package com.depromeet.threedays.data.datasource.notification
 
 import com.depromeet.threedays.data.api.NotificationHistoryService
 import com.depromeet.threedays.data.entity.notification.NotificationHistoryEntity
+import com.depromeet.threedays.data.entity.notification.NotificationHistoryReadRequest
+import com.depromeet.threedays.domain.entity.notification.NotificationHistoryStatus
 import javax.inject.Inject
 
 class NotificationHistoryRemoteDataSourceImpl @Inject constructor(
     private val notificationHistoryService: NotificationHistoryService,
 ) : NotificationHistoryRemoteDataSource {
-    override suspend fun setNotificationAsRead(notificationHistoryEntity: NotificationHistoryEntity) {
-        TODO("Not yet implemented")
-    }
-
     override suspend fun getNotificationHistories(): List<NotificationHistoryEntity> {
         return notificationHistoryService.getNotificationHistories().data ?: emptyList()
+    }
+
+    override suspend fun updateStatus(
+        notificationHistoryId: Long,
+        notificationHistoryStatus: NotificationHistoryStatus,
+    ): NotificationHistoryEntity {
+        return notificationHistoryService.updateStatus(
+            notificationHistoryId = notificationHistoryId,
+            notificationHistoryReadRequest = NotificationHistoryReadRequest(
+                status = notificationHistoryStatus,
+            ),
+        ).data!!
     }
 }

--- a/data/src/main/java/com/depromeet/threedays/data/entity/notification/NotificationHistoryReadRequest.kt
+++ b/data/src/main/java/com/depromeet/threedays/data/entity/notification/NotificationHistoryReadRequest.kt
@@ -1,0 +1,7 @@
+package com.depromeet.threedays.data.entity.notification
+
+import com.depromeet.threedays.domain.entity.notification.NotificationHistoryStatus
+
+data class NotificationHistoryReadRequest(
+    val status: NotificationHistoryStatus,
+)

--- a/data/src/main/java/com/depromeet/threedays/data/repository/NotificationHistoryRepositoryImpl.kt
+++ b/data/src/main/java/com/depromeet/threedays/data/repository/NotificationHistoryRepositoryImpl.kt
@@ -4,6 +4,7 @@ import com.depromeet.threedays.data.datasource.notification.NotificationHistoryR
 import com.depromeet.threedays.data.mapper.toNotificationHistory
 import com.depromeet.threedays.domain.entity.DataState
 import com.depromeet.threedays.domain.entity.notification.NotificationHistory
+import com.depromeet.threedays.domain.entity.notification.NotificationHistoryStatus
 import com.depromeet.threedays.domain.repository.NotificationHistoryRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
@@ -21,6 +22,23 @@ class NotificationHistoryRepositoryImpl @Inject constructor(
                         data = this.map { it.toNotificationHistory() }
                     )
                 )
+            }.runCatching {
+                emit(DataState.fail("response is fail"))
+            }
+        }
+    }
+
+    override fun updateStatus(
+        notificationHistoryId: Long,
+        notificationHistoryStatus: NotificationHistoryStatus,
+    ): Flow<DataState<NotificationHistory>> {
+        return flow {
+            emit(DataState.loading())
+            notificationHistoryRemoteDataSource.updateStatus(
+                notificationHistoryId = notificationHistoryId,
+                notificationHistoryStatus = NotificationHistoryStatus.CHECKED,
+            ).apply {
+                emit(DataState.success(data = toNotificationHistory()))
             }.runCatching {
                 emit(DataState.fail("response is fail"))
             }

--- a/domain/src/main/java/com/depromeet/threedays/domain/repository/NotificationHistoryRepository.kt
+++ b/domain/src/main/java/com/depromeet/threedays/domain/repository/NotificationHistoryRepository.kt
@@ -2,8 +2,13 @@ package com.depromeet.threedays.domain.repository
 
 import com.depromeet.threedays.domain.entity.DataState
 import com.depromeet.threedays.domain.entity.notification.NotificationHistory
+import com.depromeet.threedays.domain.entity.notification.NotificationHistoryStatus
 import kotlinx.coroutines.flow.Flow
 
 interface NotificationHistoryRepository {
     fun getNotificationHistories(): Flow<DataState<List<NotificationHistory>>>
+    fun updateStatus(
+        notificationHistoryId: Long,
+        notificationHistoryStatus: NotificationHistoryStatus,
+    ): Flow<DataState<NotificationHistory>>
 }

--- a/domain/src/main/java/com/depromeet/threedays/domain/usecase/notification/GetNotificationHistoriesUseCase.kt
+++ b/domain/src/main/java/com/depromeet/threedays/domain/usecase/notification/GetNotificationHistoriesUseCase.kt
@@ -1,4 +1,4 @@
-package com.depromeet.threedays.domain.usecase
+package com.depromeet.threedays.domain.usecase.notification
 
 import com.depromeet.threedays.domain.entity.DataState
 import com.depromeet.threedays.domain.entity.notification.NotificationHistory

--- a/domain/src/main/java/com/depromeet/threedays/domain/usecase/notification/MarkAsReadUseCase.kt
+++ b/domain/src/main/java/com/depromeet/threedays/domain/usecase/notification/MarkAsReadUseCase.kt
@@ -1,0 +1,22 @@
+package com.depromeet.threedays.domain.usecase.notification
+
+import com.depromeet.threedays.domain.entity.DataState
+import com.depromeet.threedays.domain.entity.notification.NotificationHistory
+import com.depromeet.threedays.domain.entity.notification.NotificationHistoryStatus
+import com.depromeet.threedays.domain.repository.NotificationHistoryRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+/**
+ * 알림 이력 1개 선택해서 읽음처리
+ */
+class MarkAsReadUseCase @Inject constructor(
+    private val notificationHistoryRepository: NotificationHistoryRepository,
+) {
+    operator fun invoke(notificationHistoryId: Long): Flow<DataState<NotificationHistory>> {
+        return notificationHistoryRepository.updateStatus(
+            notificationHistoryId = notificationHistoryId,
+            notificationHistoryStatus = NotificationHistoryStatus.CHECKED,
+        )
+    }
+}

--- a/presentation/home/src/main/java/com/depromeet/threedays/home/home/HomeFragment.kt
+++ b/presentation/home/src/main/java/com/depromeet/threedays/home/home/HomeFragment.kt
@@ -137,11 +137,11 @@ class HomeFragment : BaseFragment<FragmentHomeBinding, HomeViewModel>(R.layout.f
 
     private fun initEvent() {
         binding.ivNotification.setOnClickListener {
-            onNotificationClick()
+//            onNotificationClick()
             /**
              * 임시로 알림버튼 클릭 했을 때 습관 생성 화면으로 넘어갑니다 */
-//            val intent = habitCreateNavigator.intent(requireContext())
-//            addResultLauncher.launch(intent)
+            val intent = habitCreateNavigator.intent(requireContext())
+            addResultLauncher.launch(intent)
         }
     }
 

--- a/presentation/home/src/main/java/com/depromeet/threedays/home/home/HomeFragment.kt
+++ b/presentation/home/src/main/java/com/depromeet/threedays/home/home/HomeFragment.kt
@@ -137,11 +137,11 @@ class HomeFragment : BaseFragment<FragmentHomeBinding, HomeViewModel>(R.layout.f
 
     private fun initEvent() {
         binding.ivNotification.setOnClickListener {
-            //onNotificationClick()
+            onNotificationClick()
             /**
              * 임시로 알림버튼 클릭 했을 때 습관 생성 화면으로 넘어갑니다 */
-            val intent = habitCreateNavigator.intent(requireContext())
-            addResultLauncher.launch(intent)
+//            val intent = habitCreateNavigator.intent(requireContext())
+//            addResultLauncher.launch(intent)
         }
     }
 

--- a/presentation/notification/src/main/java/com/depromeet/threedays/notification/NotificationHistoryActivity.kt
+++ b/presentation/notification/src/main/java/com/depromeet/threedays/notification/NotificationHistoryActivity.kt
@@ -20,7 +20,13 @@ class NotificationHistoryActivity : BaseActivity<ActivityNotificationBinding>(R.
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        notificationAdapter = NotificationHistoryAdapter()
+        notificationAdapter = NotificationHistoryAdapter(
+            onItemClicked = {
+                viewModel.markAsRead(
+                    notificationHistoryId = it.id,
+                )
+            },
+        )
         binding.rvNotification.apply {
             layoutManager = LinearLayoutManager(context)
             adapter = notificationAdapter

--- a/presentation/notification/src/main/java/com/depromeet/threedays/notification/NotificationHistoryAdapter.kt
+++ b/presentation/notification/src/main/java/com/depromeet/threedays/notification/NotificationHistoryAdapter.kt
@@ -4,10 +4,19 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 
-class NotificationHistoryAdapter : ListAdapter<NotificationHistoryUI, NotificationHistoryViewHolder>(DIFF_UTIL) {
+class NotificationHistoryAdapter(
+    private val onItemClicked: (NotificationHistoryUI) -> Unit,
+) : ListAdapter<NotificationHistoryUI, NotificationHistoryViewHolder>(DIFF_UTIL) {
 
-    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): NotificationHistoryViewHolder {
-        return NotificationHistoryViewHolder.create(parent, false)
+    override fun onCreateViewHolder(
+        parent: ViewGroup,
+        viewType: Int,
+    ): NotificationHistoryViewHolder {
+        return NotificationHistoryViewHolder.create(
+            parent = parent,
+            attachToParent = false,
+            onItemClicked = onItemClicked,
+        )
     }
 
     override fun onBindViewHolder(holder: NotificationHistoryViewHolder, position: Int) {
@@ -22,11 +31,17 @@ class NotificationHistoryAdapter : ListAdapter<NotificationHistoryUI, Notificati
 
     companion object {
         private val DIFF_UTIL = object : DiffUtil.ItemCallback<NotificationHistoryUI>() {
-            override fun areItemsTheSame(oldItem: NotificationHistoryUI, newItem: NotificationHistoryUI): Boolean {
+            override fun areItemsTheSame(
+                oldItem: NotificationHistoryUI,
+                newItem: NotificationHistoryUI
+            ): Boolean {
                 return oldItem.id == newItem.id
             }
 
-            override fun areContentsTheSame(oldItem: NotificationHistoryUI, newItem: NotificationHistoryUI): Boolean {
+            override fun areContentsTheSame(
+                oldItem: NotificationHistoryUI,
+                newItem: NotificationHistoryUI
+            ): Boolean {
                 return oldItem == newItem
             }
         }

--- a/presentation/notification/src/main/java/com/depromeet/threedays/notification/NotificationHistoryUI.kt
+++ b/presentation/notification/src/main/java/com/depromeet/threedays/notification/NotificationHistoryUI.kt
@@ -2,12 +2,14 @@ package com.depromeet.threedays.notification
 
 import com.depromeet.threedays.domain.entity.notification.NotificationHistory
 import com.depromeet.threedays.domain.entity.notification.NotificationHistoryStatus
+import java.time.LocalDateTime
 
 data class NotificationHistoryUI(
     val id: Long,
     val title: String,
     val content: String,
     var status: NotificationHistoryStatus,
+    val createdAt: LocalDateTime,
 ) {
     companion object {
         fun from(notificationHistory: NotificationHistory) = NotificationHistoryUI(
@@ -15,6 +17,7 @@ data class NotificationHistoryUI(
             title = notificationHistory.title,
             content = notificationHistory.content,
             status = notificationHistory.status,
+            createdAt = notificationHistory.createdAt,
         )
     }
 
@@ -26,6 +29,7 @@ data class NotificationHistoryUI(
             title = this.title,
             content = this.content,
             status = status ?: this.status,
+            createdAt = this.createdAt,
         )
     }
 }

--- a/presentation/notification/src/main/java/com/depromeet/threedays/notification/NotificationHistoryUI.kt
+++ b/presentation/notification/src/main/java/com/depromeet/threedays/notification/NotificationHistoryUI.kt
@@ -1,17 +1,31 @@
 package com.depromeet.threedays.notification
 
 import com.depromeet.threedays.domain.entity.notification.NotificationHistory
+import com.depromeet.threedays.domain.entity.notification.NotificationHistoryStatus
 
 data class NotificationHistoryUI(
     val id: Long,
     val title: String,
-    val content: String
+    val content: String,
+    var status: NotificationHistoryStatus,
 ) {
     companion object {
-        fun from(notification: NotificationHistory) = NotificationHistoryUI(
-            id = notification.notificationHistoryId,
-            title = notification.title,
-            content = notification.content
+        fun from(notificationHistory: NotificationHistory) = NotificationHistoryUI(
+            id = notificationHistory.notificationHistoryId,
+            title = notificationHistory.title,
+            content = notificationHistory.content,
+            status = notificationHistory.status,
+        )
+    }
+
+    fun copyOf(
+        status: NotificationHistoryStatus?,
+    ): NotificationHistoryUI {
+        return NotificationHistoryUI(
+            id = this.id,
+            title = this.title,
+            content = this.content,
+            status = status ?: this.status,
         )
     }
 }

--- a/presentation/notification/src/main/java/com/depromeet/threedays/notification/NotificationHistoryViewHolder.kt
+++ b/presentation/notification/src/main/java/com/depromeet/threedays/notification/NotificationHistoryViewHolder.kt
@@ -3,9 +3,11 @@ package com.depromeet.threedays.notification
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
+import com.depromeet.threedays.core.extensions.formatRelatively
+import com.depromeet.threedays.domain.entity.notification.NotificationHistoryStatus
 import com.depromeet.threedays.notification.databinding.ItemNotificationBinding
 import java.time.LocalDateTime
-import java.time.format.DateTimeFormatter
+import com.depromeet.threedays.core_design_system.R as CoreDesignSystemResources
 
 class NotificationHistoryViewHolder(
     private val binding: ItemNotificationBinding,
@@ -16,8 +18,14 @@ class NotificationHistoryViewHolder(
         // 데이터 연결해주는 작업
         binding.tvNotificationTitle.text = notificationHistoryUI.title
         binding.tvNotificationContent.text = notificationHistoryUI.content
-        binding.tvTime.text = LocalDateTime.now().format(DateTimeFormatter.ofPattern("HH:mm"))
-
+        binding.tvTime.text = notificationHistoryUI.createdAt.formatRelatively(LocalDateTime.now())
+        binding.clNotificationItem.setBackgroundResource(
+            if (notificationHistoryUI.status == NotificationHistoryStatus.CHECKED) {
+                CoreDesignSystemResources.color.white
+            } else {
+                CoreDesignSystemResources.color.gray_100
+            }
+        )
         initEvent(notificationHistoryUI = notificationHistoryUI)
     }
 

--- a/presentation/notification/src/main/java/com/depromeet/threedays/notification/NotificationHistoryViewHolder.kt
+++ b/presentation/notification/src/main/java/com/depromeet/threedays/notification/NotificationHistoryViewHolder.kt
@@ -7,22 +7,39 @@ import com.depromeet.threedays.notification.databinding.ItemNotificationBinding
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
-class NotificationHistoryViewHolder(private val binding: ItemNotificationBinding) : RecyclerView.ViewHolder(binding.root) {
-    fun onBind(notificationUI: NotificationHistoryUI) {
+class NotificationHistoryViewHolder(
+    private val binding: ItemNotificationBinding,
+    private val onItemClicked: (NotificationHistoryUI) -> Unit,
+) : RecyclerView.ViewHolder(binding.root) {
+
+    fun onBind(notificationHistoryUI: NotificationHistoryUI) {
         // 데이터 연결해주는 작업
-        binding.tvNotificationTitle.text = notificationUI.title
-        binding.tvNotificationContent.text = notificationUI.content
-        binding.tvTime.text = LocalDateTime.now().format(DateTimeFormatter.ofPattern("HH:mm"));
+        binding.tvNotificationTitle.text = notificationHistoryUI.title
+        binding.tvNotificationContent.text = notificationHistoryUI.content
+        binding.tvTime.text = LocalDateTime.now().format(DateTimeFormatter.ofPattern("HH:mm"))
+
+        initEvent(notificationHistoryUI = notificationHistoryUI)
+    }
+
+    private fun initEvent(notificationHistoryUI: NotificationHistoryUI) {
+        binding.clNotificationItem.setOnClickListener {
+            onItemClicked(notificationHistoryUI)
+        }
     }
 
     companion object {
-        fun create(parent: ViewGroup, attachToParent: Boolean): NotificationHistoryViewHolder {
+        fun create(
+            parent: ViewGroup,
+            attachToParent: Boolean,
+            onItemClicked: (NotificationHistoryUI) -> Unit,
+        ): NotificationHistoryViewHolder {
             return NotificationHistoryViewHolder(
-                ItemNotificationBinding.inflate(
+                binding = ItemNotificationBinding.inflate(
                     LayoutInflater.from(parent.context),
                     parent,
-                    attachToParent
-                )
+                    attachToParent,
+                ),
+                onItemClicked = onItemClicked,
             )
         }
     }

--- a/presentation/notification/src/main/java/com/depromeet/threedays/notification/NotificationHistoryViewModel.kt
+++ b/presentation/notification/src/main/java/com/depromeet/threedays/notification/NotificationHistoryViewModel.kt
@@ -3,7 +3,8 @@ package com.depromeet.threedays.notification
 import androidx.lifecycle.viewModelScope
 import com.depromeet.threedays.core.BaseViewModel
 import com.depromeet.threedays.domain.entity.Status
-import com.depromeet.threedays.domain.usecase.GetNotificationHistoriesUseCase
+import com.depromeet.threedays.domain.usecase.notification.GetNotificationHistoriesUseCase
+import com.depromeet.threedays.domain.usecase.notification.MarkAsReadUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -13,6 +14,7 @@ import javax.inject.Inject
 @HiltViewModel
 class NotificationHistoryViewModel @Inject constructor(
     private val getNotificationHistoriesUseCase: GetNotificationHistoriesUseCase,
+    private val markAsReadUseCase: MarkAsReadUseCase,
 ) : BaseViewModel() {
 
     private val _notifications: MutableStateFlow<List<NotificationHistoryUI>> =
@@ -20,16 +22,50 @@ class NotificationHistoryViewModel @Inject constructor(
     val notifications: StateFlow<List<NotificationHistoryUI>>
         get() = _notifications
 
+    /**
+     * 알림 페이지 > 알림 이력 목록 조회
+     */
     fun fetchNotifications() {
         viewModelScope.launch {
             getNotificationHistoriesUseCase().collect { response ->
                 when (response.status) {
-                    Status.LOADING -> {}
+                    Status.LOADING -> {
+                        // Do nothing
+                    }
                     Status.SUCCESS -> {
                         _notifications.value = response.data!!.map { NotificationHistoryUI.from(it) }
                     }
-                    Status.ERROR -> {}
-                    Status.FAIL -> {}
+                    Status.ERROR -> TODO()
+                    Status.FAIL -> TODO()
+                }
+            }
+        }
+    }
+
+    /**
+     * 알림 페이지 > 알림 이력 읽음 처리
+     */
+    fun markAsRead(notificationHistoryId: Long) {
+        viewModelScope.launch {
+            markAsReadUseCase(notificationHistoryId).collect { response ->
+                when (response.status) {
+                    Status.LOADING -> {
+                        // Do nothing
+                    }
+                    Status.SUCCESS -> {
+                        val notificationHistory = response.data!!
+                        _notifications.value = _notifications.value.map {
+                            if (notificationHistory.notificationHistoryId != it.id) {
+                                it
+                            } else {
+                                it.copyOf(
+                                    status = notificationHistory.status,
+                                )
+                            }
+                        }
+                    }
+                    Status.ERROR -> TODO()
+                    Status.FAIL -> TODO()
                 }
             }
         }

--- a/presentation/notification/src/main/res/layout/item_notification.xml
+++ b/presentation/notification/src/main/res/layout/item_notification.xml
@@ -7,6 +7,7 @@
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/cl_notification_item"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:background="@color/gray_100">


### PR DESCRIPTION
## 💁‍♂️ 변경 내용
### TO-BE
- 알림 읽음 처리 API 연동 (`PATCH /api/v1/notifications/{notificationHistoryId}`)
- 알림 시각 format 적용
  - 현재시각과 비교해서 오늘 받은 알람이면 `HH:mm`, 오늘보다 전에 받은 알람이면 `yyyy.MM.dd` 로 표시

## 📢 전달사항
- 없습니다