### PR TITLE
DEP-248 feat: 로그아웃 API 연동

### DIFF
--- a/data/src/main/java/com/depromeet/threedays/data/api/MemberService.kt
+++ b/data/src/main/java/com/depromeet/threedays/data/api/MemberService.kt
@@ -1,11 +1,13 @@
 package com.depromeet.threedays.data.api
 
 import com.depromeet.threedays.data.entity.base.ApiResponse
+import com.depromeet.threedays.data.entity.member.LogoutRequest
 import com.depromeet.threedays.data.entity.member.MemberEntity
 import com.depromeet.threedays.data.entity.member.UpdateNicknameRequest
 import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.PATCH
+import retrofit2.http.POST
 
 interface MemberService {
     @GET("/api/v1/members/me")
@@ -13,6 +15,11 @@ interface MemberService {
 
     @PATCH("/api/v1/members/name")
     suspend fun updateName(
-        @Body updateNicknameRequest: UpdateNicknameRequest
+        @Body updateNicknameRequest: UpdateNicknameRequest,
     ): ApiResponse<MemberEntity>
+
+    @POST("/api/v1/members/logout")
+    suspend fun logout(
+        @Body logoutRequest: LogoutRequest,
+    ): ApiResponse<Unit>
 }

--- a/data/src/main/java/com/depromeet/threedays/data/datasource/member/MemberRemoteDataSource.kt
+++ b/data/src/main/java/com/depromeet/threedays/data/datasource/member/MemberRemoteDataSource.kt
@@ -5,4 +5,5 @@ import com.depromeet.threedays.data.entity.member.MemberEntity
 interface MemberRemoteDataSource {
     suspend fun getMyInfo(): MemberEntity
     suspend fun updateNickname(nickname: String): MemberEntity
+    suspend fun logout(deviceId: String)
 }

--- a/data/src/main/java/com/depromeet/threedays/data/datasource/member/MemberRemoteDataSourceImpl.kt
+++ b/data/src/main/java/com/depromeet/threedays/data/datasource/member/MemberRemoteDataSourceImpl.kt
@@ -1,6 +1,7 @@
 package com.depromeet.threedays.data.datasource.member
 
 import com.depromeet.threedays.data.api.MemberService
+import com.depromeet.threedays.data.entity.member.LogoutRequest
 import com.depromeet.threedays.data.entity.member.MemberEntity
 import com.depromeet.threedays.data.entity.member.UpdateNicknameRequest
 import javax.inject.Inject
@@ -18,5 +19,13 @@ class MemberRemoteDataSourceImpl @Inject constructor(
                 name = nickname,
             ),
         ).data!!
+    }
+
+    override suspend fun logout(deviceId: String) {
+        memberService.logout(
+            logoutRequest = LogoutRequest(
+                identificationKey = deviceId,
+            ),
+        )
     }
 }

--- a/data/src/main/java/com/depromeet/threedays/data/entity/member/LogoutRequest.kt
+++ b/data/src/main/java/com/depromeet/threedays/data/entity/member/LogoutRequest.kt
@@ -1,0 +1,8 @@
+package com.depromeet.threedays.data.entity.member
+
+data class LogoutRequest(
+    /**
+     * 기기 식별자
+     */
+    val identificationKey: String,
+)

--- a/data/src/main/java/com/depromeet/threedays/data/repository/MemberRepositoryImpl.kt
+++ b/data/src/main/java/com/depromeet/threedays/data/repository/MemberRepositoryImpl.kt
@@ -41,4 +41,17 @@ class MemberRepositoryImpl @Inject constructor(
             }
         }
     }
+
+    override fun logout(deviceId: String): Flow<DataState<Unit>> {
+        return flow {
+            emit(DataState.loading())
+            memberRemoteDataSource.logout(deviceId = deviceId).apply {
+                emit(
+                    DataState.success(data = Unit)
+                )
+            }.runCatching {
+                emit(DataState.fail("Failed to get response"))
+            }
+        }
+    }
 }

--- a/domain/src/main/java/com/depromeet/threedays/domain/repository/MemberRepository.kt
+++ b/domain/src/main/java/com/depromeet/threedays/domain/repository/MemberRepository.kt
@@ -7,4 +7,5 @@ import kotlinx.coroutines.flow.Flow
 interface MemberRepository {
     fun getMyInfo(): Flow<DataState<Member>>
     fun updateNickname(nickname: String): Flow<DataState<Member>>
+    fun logout(deviceId: String): Flow<DataState<Unit>>
 }

--- a/domain/src/main/java/com/depromeet/threedays/domain/usecase/member/GetMyInfoUseCase.kt
+++ b/domain/src/main/java/com/depromeet/threedays/domain/usecase/member/GetMyInfoUseCase.kt
@@ -7,7 +7,7 @@ import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 
 class GetMyInfoUseCase @Inject constructor(
-    private val memberRepository: MemberRepository
+    private val memberRepository: MemberRepository,
 ) {
     operator fun invoke(): Flow<DataState<Member>> {
         return memberRepository.getMyInfo()

--- a/domain/src/main/java/com/depromeet/threedays/domain/usecase/member/LogoutUseCase.kt
+++ b/domain/src/main/java/com/depromeet/threedays/domain/usecase/member/LogoutUseCase.kt
@@ -1,0 +1,17 @@
+package com.depromeet.threedays.domain.usecase.member
+
+import com.depromeet.threedays.domain.entity.DataState
+import com.depromeet.threedays.domain.repository.MemberRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class LogoutUseCase @Inject constructor(
+    private val memberRepository: MemberRepository,
+) {
+    operator fun invoke(): Flow<DataState<Unit>> {
+        // TODO: deviceId 조회 기능 추가
+        val deviceId = "identificationKey"
+        return memberRepository.logout(deviceId = deviceId)
+        // TODO: 성공하면 accessToken, refreshToken 삭제
+    }
+}

--- a/presentation/mypage/src/main/java/com/depromeet/threedays/mypage/MyPageFragment.kt
+++ b/presentation/mypage/src/main/java/com/depromeet/threedays/mypage/MyPageFragment.kt
@@ -51,6 +51,9 @@ class MyPageFragment :
         binding.ivEdit.setOnClickListener {
             onEditButtonClicked()
         }
+        binding.tvLogout.setOnClickListener {
+            onLogoutButtonClicked()
+        }
     }
 
     /**
@@ -97,6 +100,14 @@ class MyPageFragment :
 
     private fun onPrivacyPolicyButtonClicked() {
         TODO("개인정보처리방침")
+    }
+
+    /**
+     * 마이페이지 > 로그아웃 버튼
+     */
+    private fun onLogoutButtonClicked() {
+        viewModel.logout()
+        // TODO: login 페이지로 이동
     }
 
 }

--- a/presentation/mypage/src/main/java/com/depromeet/threedays/mypage/MyPageViewModel.kt
+++ b/presentation/mypage/src/main/java/com/depromeet/threedays/mypage/MyPageViewModel.kt
@@ -5,6 +5,7 @@ import com.depromeet.threedays.core.BaseViewModel
 import com.depromeet.threedays.core.extensions.Empty
 import com.depromeet.threedays.domain.entity.Status
 import com.depromeet.threedays.domain.usecase.member.GetMyInfoUseCase
+import com.depromeet.threedays.domain.usecase.member.LogoutUseCase
 import com.depromeet.threedays.domain.usecase.member.UpdateNicknameUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -16,6 +17,7 @@ import javax.inject.Inject
 class MyPageViewModel @Inject constructor(
     private val getMyInfoUseCase: GetMyInfoUseCase,
     private val updateNicknameUseCase: UpdateNicknameUseCase,
+    private val logoutUseCase: LogoutUseCase,
 ) : BaseViewModel() {
     private val _nickname: MutableStateFlow<String> = MutableStateFlow(String.Empty)
     val nickname: StateFlow<String>
@@ -53,6 +55,26 @@ class MyPageViewModel @Inject constructor(
                     }
                     Status.SUCCESS -> {
                         _nickname.value = response.data!!.name
+                    }
+                    Status.ERROR -> TODO()
+                    Status.FAIL -> TODO()
+                }
+            }
+        }
+    }
+
+    /**
+     * 로그아웃
+     */
+    fun logout() {
+        viewModelScope.launch {
+            logoutUseCase().collect { response ->
+                when (response.status) {
+                    Status.LOADING -> {
+                        // Do nothing
+                    }
+                    Status.SUCCESS -> {
+                        // Do nothing
                     }
                     Status.ERROR -> TODO()
                     Status.FAIL -> TODO()

--- a/presentation/mypage/src/main/res/layout/fragment_my_page.xml
+++ b/presentation/mypage/src/main/res/layout/fragment_my_page.xml
@@ -191,6 +191,7 @@
                 app:layout_constraintStart_toStartOf="parent" />
 
             <TextView
+                android:id="@+id/tv_logout"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginEnd="40dp"


### PR DESCRIPTION
## 💁‍♂️ 변경 내용
### TO-BE
- 로그아웃 API 연동 (`POST /api/v1/members/logout`)
## 📢 전달사항
- 저장했던 토큰(accessToken, refreshToken) 삭제, 로그아웃 성공시 로그인 페이지로 이동 필요

