### PR TITLE
DEP-249 feat: 회원탈퇴 API 연동

### DIFF
--- a/data/src/main/java/com/depromeet/threedays/data/api/MemberService.kt
+++ b/data/src/main/java/com/depromeet/threedays/data/api/MemberService.kt
@@ -5,6 +5,7 @@ import com.depromeet.threedays.data.entity.member.LogoutRequest
 import com.depromeet.threedays.data.entity.member.MemberEntity
 import com.depromeet.threedays.data.entity.member.UpdateNicknameRequest
 import retrofit2.http.Body
+import retrofit2.http.DELETE
 import retrofit2.http.GET
 import retrofit2.http.PATCH
 import retrofit2.http.POST
@@ -22,4 +23,7 @@ interface MemberService {
     suspend fun logout(
         @Body logoutRequest: LogoutRequest,
     ): ApiResponse<Unit>
+
+    @DELETE("/api/v1/members")
+    suspend fun withdraw(): ApiResponse<Unit>
 }

--- a/data/src/main/java/com/depromeet/threedays/data/datasource/member/MemberRemoteDataSource.kt
+++ b/data/src/main/java/com/depromeet/threedays/data/datasource/member/MemberRemoteDataSource.kt
@@ -6,4 +6,5 @@ interface MemberRemoteDataSource {
     suspend fun getMyInfo(): MemberEntity
     suspend fun updateNickname(nickname: String): MemberEntity
     suspend fun logout(deviceId: String)
+    suspend fun withdraw()
 }

--- a/data/src/main/java/com/depromeet/threedays/data/datasource/member/MemberRemoteDataSourceImpl.kt
+++ b/data/src/main/java/com/depromeet/threedays/data/datasource/member/MemberRemoteDataSourceImpl.kt
@@ -28,4 +28,8 @@ class MemberRemoteDataSourceImpl @Inject constructor(
             ),
         )
     }
+
+    override suspend fun withdraw() {
+        memberService.withdraw()
+    }
 }

--- a/data/src/main/java/com/depromeet/threedays/data/repository/MemberRepositoryImpl.kt
+++ b/data/src/main/java/com/depromeet/threedays/data/repository/MemberRepositoryImpl.kt
@@ -46,9 +46,18 @@ class MemberRepositoryImpl @Inject constructor(
         return flow {
             emit(DataState.loading())
             memberRemoteDataSource.logout(deviceId = deviceId).apply {
-                emit(
-                    DataState.success(data = Unit)
-                )
+                emit(DataState.success(data = Unit))
+            }.runCatching {
+                emit(DataState.fail("Failed to get response"))
+            }
+        }
+    }
+
+    override fun withdraw(): Flow<DataState<Unit>> {
+        return flow {
+            emit(DataState.loading())
+            memberRemoteDataSource.withdraw().apply {
+                emit(DataState.success(data = Unit))
             }.runCatching {
                 emit(DataState.fail("Failed to get response"))
             }

--- a/domain/src/main/java/com/depromeet/threedays/domain/repository/MemberRepository.kt
+++ b/domain/src/main/java/com/depromeet/threedays/domain/repository/MemberRepository.kt
@@ -8,4 +8,5 @@ interface MemberRepository {
     fun getMyInfo(): Flow<DataState<Member>>
     fun updateNickname(nickname: String): Flow<DataState<Member>>
     fun logout(deviceId: String): Flow<DataState<Unit>>
+    fun withdraw(): Flow<DataState<Unit>>
 }

--- a/domain/src/main/java/com/depromeet/threedays/domain/usecase/member/WithdrawUseCase.kt
+++ b/domain/src/main/java/com/depromeet/threedays/domain/usecase/member/WithdrawUseCase.kt
@@ -1,0 +1,15 @@
+package com.depromeet.threedays.domain.usecase.member
+
+import com.depromeet.threedays.domain.entity.DataState
+import com.depromeet.threedays.domain.repository.MemberRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class WithdrawUseCase @Inject constructor(
+    private val memberRepository: MemberRepository,
+) {
+    operator fun invoke(): Flow<DataState<Unit>> {
+        return memberRepository.withdraw()
+        // TODO: accessToken, refreshToken 삭제
+    }
+}

--- a/presentation/mypage/src/main/java/com/depromeet/threedays/mypage/MyPageFragment.kt
+++ b/presentation/mypage/src/main/java/com/depromeet/threedays/mypage/MyPageFragment.kt
@@ -54,6 +54,9 @@ class MyPageFragment :
         binding.tvLogout.setOnClickListener {
             onLogoutButtonClicked()
         }
+        binding.tvWithdraw.setOnClickListener {
+            onWithdrawButtonClicked()
+        }
     }
 
     /**
@@ -110,4 +113,11 @@ class MyPageFragment :
         // TODO: login 페이지로 이동
     }
 
+    /**
+     * 마이페이지 > 회원탈퇴 버튼
+     */
+    private fun onWithdrawButtonClicked() {
+        viewModel.withdraw()
+        // TODO: 로그인 페이지로 이동
+    }
 }

--- a/presentation/mypage/src/main/java/com/depromeet/threedays/mypage/MyPageViewModel.kt
+++ b/presentation/mypage/src/main/java/com/depromeet/threedays/mypage/MyPageViewModel.kt
@@ -7,6 +7,7 @@ import com.depromeet.threedays.domain.entity.Status
 import com.depromeet.threedays.domain.usecase.member.GetMyInfoUseCase
 import com.depromeet.threedays.domain.usecase.member.LogoutUseCase
 import com.depromeet.threedays.domain.usecase.member.UpdateNicknameUseCase
+import com.depromeet.threedays.domain.usecase.member.WithdrawUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -18,6 +19,7 @@ class MyPageViewModel @Inject constructor(
     private val getMyInfoUseCase: GetMyInfoUseCase,
     private val updateNicknameUseCase: UpdateNicknameUseCase,
     private val logoutUseCase: LogoutUseCase,
+    private val withdrawUseCase: WithdrawUseCase,
 ) : BaseViewModel() {
     private val _nickname: MutableStateFlow<String> = MutableStateFlow(String.Empty)
     val nickname: StateFlow<String>
@@ -69,6 +71,26 @@ class MyPageViewModel @Inject constructor(
     fun logout() {
         viewModelScope.launch {
             logoutUseCase().collect { response ->
+                when (response.status) {
+                    Status.LOADING -> {
+                        // Do nothing
+                    }
+                    Status.SUCCESS -> {
+                        // Do nothing
+                    }
+                    Status.ERROR -> TODO()
+                    Status.FAIL -> TODO()
+                }
+            }
+        }
+    }
+
+    /**
+     * 회원 탈퇴
+     */
+    fun withdraw() {
+        viewModelScope.launch {
+            withdrawUseCase().collect { response ->
                 when (response.status) {
                     Status.LOADING -> {
                         // Do nothing

--- a/presentation/mypage/src/main/res/layout/fragment_my_page.xml
+++ b/presentation/mypage/src/main/res/layout/fragment_my_page.xml
@@ -202,6 +202,7 @@
                 app:layout_constraintEnd_toStartOf="@id/iv_divider" />
 
             <TextView
+                android:id="@+id/tv_withdraw"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="40dp"


### PR DESCRIPTION
## 💁‍♂️ 변경 내용
### TO-BE
- 회원 탈퇴 API 연동 (`DELETE /api/v1/members`)

## 📢 전달사항
- 회원 탈퇴 후 토큰 삭제, 로그인페이지로 이동 필요