### PR TITLE
DEP-295 fix: android 12 기기에서 스플래시 스크린 멈춤 현상 해결

### DIFF
--- a/presentation/splash/src/main/java/com/depromeet/threedays/splash/SplashActivity.kt
+++ b/presentation/splash/src/main/java/com/depromeet/threedays/splash/SplashActivity.kt
@@ -1,6 +1,8 @@
 package com.depromeet.threedays.splash
 
 import android.annotation.SuppressLint
+import android.os.Build
+import android.os.Build.VERSION.SDK_INT
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
@@ -22,25 +24,39 @@ class SplashActivity : BaseActivity<ActivitySplashBinding>(R.layout.activity_spl
     override fun onCreate(savedInstanceState: Bundle?) {
         // onCreate 보다 먼저 호출해야함
         val splashScreen = installSplashScreen()
-        splashScreen.setOnExitAnimationListener {
-            val displayMetrics = DisplayMetrics()
-            windowManager.defaultDisplay.getMetrics(displayMetrics)
-            val width = displayMetrics.widthPixels
-
-            binding.animationView.apply {
-                layoutParams.width = (width * 0.61).toInt() // 220/360 = 0.611
-                layoutParams.height = layoutParams.width
-                setAnimation(R.raw.lottie_splash)
-                repeatCount = 1
+        if (SDK_INT < Build.VERSION_CODES.S) {
+            splashScreen.setOnExitAnimationListener {
                 playAnimation()
+                it.remove()
+                goToHomeActivityWithDelay()
             }
-            it.remove()
-            Handler(Looper.getMainLooper()).postDelayed({
-                startActivity(homeNavigator.intent(applicationContext))
-                finish()
-            }, DELAYED_MILLIS)
         }
         super.onCreate(savedInstanceState)
+        // XXX: API 31 기기에서 스플래시 스크린 안넘어가는 현상 임시 해결
+        if (SDK_INT >= Build.VERSION_CODES.S) {
+            playAnimation()
+            goToHomeActivityWithDelay()
+        }
+    }
+
+    private fun playAnimation() {
+        val displayMetrics = DisplayMetrics()
+        windowManager.defaultDisplay.getMetrics(displayMetrics)
+        val width = displayMetrics.widthPixels
+        binding.animationView.apply {
+            layoutParams.width = (width * 0.61).toInt() // 220/360 = 0.611
+            layoutParams.height = layoutParams.width
+            setAnimation(R.raw.lottie_splash)
+            repeatCount = 1
+            playAnimation()
+        }
+    }
+
+    private fun goToHomeActivityWithDelay() {
+        Handler(Looper.getMainLooper()).postDelayed({
+            startActivity(homeNavigator.intent(applicationContext))
+            finish()
+        }, DELAYED_MILLIS)
     }
 
     companion object {


### PR DESCRIPTION
## 💁‍♂️ 변경 내용
### TO-BE
- S20 (API 31, Android 12) 에서 스플래시스크린 못넘어가고 멈추는 현상 해결

## 📢 전달사항
- 왜안됐는지, 왜 해결되었는지 둘 다 모르는 상태에요 ㅠ_ㅠ
