### PR TITLE
config: ci 환경에 debug keystore 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,16 +23,20 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
           restore-keys: ${{ runner.os }}-gradle
       - name: Fetch keystore file from secrets
-        run: echo $KEYSTORE_DEBUG | base64 -d > debug.keystore
+        run: echo $DEBUG_KEYSTORE_FILE | base64 -d > debug.keystore
       - name: Build
-        run: chmod +x ./gradlew && ./gradlew --quiet build
+        run: chmod +x ./gradlew && ./gradlew --quiet -PbuildType=debug -PsigningConfig=ci :app:assemble
+        env:
+          DEBUG_STORE_PASSWORD: ${{ secrets.DEBUG_STORE_PASSWORD }}
+          DEBUG_KEY_PASSWORD: ${{ secrets.DEBUG_KEY_PASSWORD }}
+          DEBUG_KEY_ALIAS: ${{ secrets.DEBUG_KEY_ALIAS }}
       - name: Fetch credential file from secrets
         run: echo $FIREBASE_CREDENTIAL_FILE | base64 -d > credential_file.json
       - name: Upload artifact to Firebase Distribution using credential file
         uses: wzieba/Firebase-Distribution-Github-Action@v1.3.5
         with:
-          appId: ${{secrets.FIREBASE_APP_ID}}
-          token: ${{secrets.FIREBASE_TOKEN}}
+          appId: ${{ secrets.FIREBASE_APP_ID }}
+          token: ${{ secrets.FIREBASE_TOKEN }}
           serviceCredentialsFile: credential_file.json
           groups: android
           file: app/build/outputs/apk/debug/app-debug.apk

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Fetch keystore file from secrets
         run: echo $DEBUG_KEYSTORE_FILE | base64 -d > debug.keystore
       - name: Build
-        run: chmod +x ./gradlew && ./gradlew --quiet -PbuildType=debug -PsigningConfig=ci :app:assemble
+        run: chmod +x ./gradlew && ./gradlew --quiet -PbuildType=debug -PsigningConfig=ciDebug :app:assemble
         env:
           DEBUG_STORE_PASSWORD: ${{ secrets.DEBUG_STORE_PASSWORD }}
           DEBUG_KEY_PASSWORD: ${{ secrets.DEBUG_KEY_PASSWORD }}

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,6 +23,15 @@ android {
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
+    signingConfigs {
+        ciDebug {
+            storeFile file("$project.rootDir/debug.keystore")
+            storePassword System.getenv('DEBUG_STORE_PASSWORD')
+            keyPassword System.getenv('DEBUG_KEY_PASSWORD')
+            keyAlias System.getenv('DEBUG_KEY_ALIAS')
+        }
+    }
+
     buildTypes {
         release {
             minifyEnabled false


### PR DESCRIPTION
## 💁‍♂️ 변경 내용
### AS-IS
- 깃헙액션에서 빌드한 apk 는 카카오 sdk 사용못함
### TO-BE
- app build.gradle 에 signingConfigs.ciDebug 추가함
  - 나중에 ciRelease 도 같은 방법으로 추가 가능
- GitHub Action Secrets 에 debug.keystore 및 password 등 추가

## 📢 전달사항
- 카카오 키해시 등록함
