### PR TITLE
DEP-325 fix: 짝꿍 온보딩 모달이 여러개 뜨는 버그 수정

### DIFF
--- a/presentation/mate/src/main/java/com/depromeet/threedays/mate/MateFragment.kt
+++ b/presentation/mate/src/main/java/com/depromeet/threedays/mate/MateFragment.kt
@@ -117,7 +117,6 @@ class MateFragment: BaseFragment<FragmentMateBinding, MateViewModel>(R.layout.fr
                         )
                         setMateInfo(mateUI = it.mate)
                         setHabitInfo(habit = it.habit)
-                        showMateOnboarding(it.isFirstVisitor)
                         clapAdapter.submitList(it.stamps)
                     }
                 }
@@ -127,6 +126,12 @@ class MateFragment: BaseFragment<FragmentMateBinding, MateViewModel>(R.layout.fr
                         when(it) {
                             is UiEffect.ShowToastMessage -> showDeleteSuccessMessage(it.resId)
                         }
+                    }
+                }
+
+                launch {
+                    viewModel.isFirstVisitor.collect {
+                        showMateOnboarding(isFirstVisitor = it)
                     }
                 }
             }

--- a/presentation/mate/src/main/java/com/depromeet/threedays/mate/MateViewModel.kt
+++ b/presentation/mate/src/main/java/com/depromeet/threedays/mate/MateViewModel.kt
@@ -36,6 +36,9 @@ class MateViewModel @Inject constructor(
     val uiEffect: SharedFlow<UiEffect>
         get() = _uiEffect
 
+    private val _isFirstVisitor: MutableStateFlow<Boolean> = MutableStateFlow(false)
+    val isFirstVisitor: StateFlow<Boolean>
+        get() = _isFirstVisitor
 
     init {
         checkIsFirstVisitor()
@@ -95,12 +98,10 @@ class MateViewModel @Inject constructor(
 
     private fun checkIsFirstVisitor() {
         viewModelScope.launch {
-            if(uiState.value.isFirstVisitor.not()) {
+            if (isFirstVisitor.value.not()) {
                 val response = readOnboardingUseCase.execute(IS_FIRST_VISIT_ONBOARDING_MATE)
-                _uiState.update {
-                    it.copy(
-                        isFirstVisitor = response == null || response == "true"
-                    )
+                _isFirstVisitor.update {
+                    response == null || response == "true"
                 }
             }
         }
@@ -200,7 +201,6 @@ data class UiState(
     val habit: SingleHabit? = null,
     val hasMate: Boolean = false,
     val backgroundResColor: Int = core_design.color.gray_100,
-    val isFirstVisitor: Boolean = false,
     val stamps: List<StampUI> = emptyList(),
 )
 


### PR DESCRIPTION
온보딩 확인 여부를 다른 state와 하나의 data class로 관리했더니
update가 여러 번 되는 문제가 생기네요.

온보딩 확인 state를 별도로 분리해서 해결했습니다.