### PR TITLE
DEP-329 fix: 짝꿍 생성시 습관 선택이 제대로 되지 않는 버그 수정

### DIFF
--- a/presentation/mate/src/main/java/com/depromeet/threedays/mate/create/step1/ConnectHabitAdapter.kt
+++ b/presentation/mate/src/main/java/com/depromeet/threedays/mate/create/step1/ConnectHabitAdapter.kt
@@ -9,15 +9,24 @@ class ConnectHabitAdapter(
     private val setHabitClickStatus: (HabitUI) -> Unit,
 ) : ListAdapter<HabitUI, ConnectHabitViewHolder>(DIFF_UTIL) {
     private var selectCheck = mutableListOf<Boolean>()
+    private var checkedItem = 0
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int) =
         ConnectHabitViewHolder.create(parent, false)
 
     override fun onBindViewHolder(holder: ConnectHabitViewHolder, position: Int) {
+        val realPosition = holder.bindingAdapterPosition
+
         holder.onBind(
             getItem(position),
-            selectCheck[position],
-            onRadioButtonClick = { selectCheck[position] = it },
+            selectCheck[realPosition],
+            onRadioButtonClick = {
+                selectCheck[checkedItem] = false
+                notifyItemChanged(checkedItem)
+
+                checkedItem = realPosition
+                selectCheck[realPosition] = true
+            },
             setHabitClickStatus = { setHabitClickStatus(it) }
         )
     }

--- a/presentation/mate/src/main/java/com/depromeet/threedays/mate/create/step1/ConnectHabitAdapter.kt
+++ b/presentation/mate/src/main/java/com/depromeet/threedays/mate/create/step1/ConnectHabitAdapter.kt
@@ -8,22 +8,31 @@ import com.depromeet.threedays.mate.create.step1.model.HabitUI
 class ConnectHabitAdapter(
     private val setHabitClickStatus: (HabitUI) -> Unit,
 ) : ListAdapter<HabitUI, ConnectHabitViewHolder>(DIFF_UTIL) {
+    private var selectCheck = mutableListOf<Boolean>()
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int) =
-        ConnectHabitViewHolder.create(
-            parent = parent,
-            attachToParent = false,
-            setHabitClickStatus = setHabitClickStatus,
-        )
+        ConnectHabitViewHolder.create(parent, false)
 
     override fun onBindViewHolder(holder: ConnectHabitViewHolder, position: Int) {
-        holder.onBind(getItem(position))
+        holder.onBind(
+            getItem(position),
+            selectCheck[position],
+            onRadioButtonClick = { selectCheck[position] = it },
+            setHabitClickStatus = { setHabitClickStatus(it) }
+        )
     }
 
     override fun getItemCount(): Int = currentList.size
 
     override fun getItemId(position: Int): Long {
         return getItem(position).habitId
+    }
+
+    override fun submitList(list: List<HabitUI>?) {
+        super.submitList(list)
+        selectCheck = generateSequence(false) { it }
+            .take(list?.size ?: 0)
+            .toMutableList()
     }
 
     companion object {

--- a/presentation/mate/src/main/java/com/depromeet/threedays/mate/create/step1/ConnectHabitViewHolder.kt
+++ b/presentation/mate/src/main/java/com/depromeet/threedays/mate/create/step1/ConnectHabitViewHolder.kt
@@ -4,20 +4,26 @@ import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import com.depromeet.threedays.core.setOnSingleClickListener
-import com.depromeet.threedays.mate.R
 import com.depromeet.threedays.mate.create.step1.model.HabitUI
 import com.depromeet.threedays.mate.databinding.ItemConnectHabitBinding
 
 class ConnectHabitViewHolder(
     private val binding: ItemConnectHabitBinding,
-    private val setHabitClickStatus: (HabitUI) -> Unit,
 ) : RecyclerView.ViewHolder(binding.root) {
 
-    fun onBind(habitUI: HabitUI) {
+    fun onBind(
+        habitUI: HabitUI,
+        selectCheck: Boolean,
+        onRadioButtonClick: (Boolean) -> Unit,
+        setHabitClickStatus: (HabitUI) -> Unit,
+    ) {
         binding.habitUI = habitUI
-        binding.clHabit.setOnSingleClickListener {
-            setHabitClickStatus(habitUI)
-            binding.clHabit.setBackgroundResource(R.drawable.bg_rect_gray_200_border_gray_400_r10)
+        binding.rbHabit.apply {
+            isChecked = selectCheck
+            setOnSingleClickListener {
+                setHabitClickStatus(habitUI)
+                onRadioButtonClick(isChecked)
+            }
         }
     }
 
@@ -25,12 +31,10 @@ class ConnectHabitViewHolder(
         fun create(
             parent: ViewGroup,
             attachToParent: Boolean,
-            setHabitClickStatus: (HabitUI) -> Unit,
         ) = ConnectHabitViewHolder(
             binding = ItemConnectHabitBinding.inflate(
                 LayoutInflater.from(parent.context), parent, attachToParent
-            ),
-            setHabitClickStatus = setHabitClickStatus,
+            )
         )
     }
 }

--- a/presentation/mate/src/main/java/com/depromeet/threedays/mate/create/step1/ConnectHabitViewHolder.kt
+++ b/presentation/mate/src/main/java/com/depromeet/threedays/mate/create/step1/ConnectHabitViewHolder.kt
@@ -14,7 +14,7 @@ class ConnectHabitViewHolder(
     fun onBind(
         habitUI: HabitUI,
         selectCheck: Boolean,
-        onRadioButtonClick: (Boolean) -> Unit,
+        onRadioButtonClick: () -> Unit,
         setHabitClickStatus: (HabitUI) -> Unit,
     ) {
         binding.habitUI = habitUI
@@ -22,7 +22,7 @@ class ConnectHabitViewHolder(
             isChecked = selectCheck
             setOnSingleClickListener {
                 setHabitClickStatus(habitUI)
-                onRadioButtonClick(isChecked)
+                onRadioButtonClick()
             }
         }
     }

--- a/presentation/mate/src/main/java/com/depromeet/threedays/mate/create/step1/ConnectHabitViewModel.kt
+++ b/presentation/mate/src/main/java/com/depromeet/threedays/mate/create/step1/ConnectHabitViewModel.kt
@@ -54,16 +54,6 @@ class ConnectHabitViewModel @Inject constructor(
     }
 
     fun setHabitClickStatus(clickedHabit: HabitUI) {
-        // TODO: mock server에서 모든 id가 0으로 넘어오고 있음. api 변경 후 동작확인 필요 
-        
-        _habits.update { list ->
-            list.map {
-                it.copy(
-                    clicked = it.habitId == clickedHabit.habitId
-                )
-            }
-        }
-
         _uiState.update {
             it.copy(
                 clickedHabit = clickedHabit,

--- a/presentation/mate/src/main/java/com/depromeet/threedays/mate/create/step1/model/HabitUI.kt
+++ b/presentation/mate/src/main/java/com/depromeet/threedays/mate/create/step1/model/HabitUI.kt
@@ -10,7 +10,6 @@ data class HabitUI(
     val title: String,
     val imojiPath: String,
     val color: Color,
-    val clicked: Boolean = false
 ) : Parcelable
 
 fun Habit.toHabitUI(): HabitUI {

--- a/presentation/mate/src/main/res/drawable/selector_gray_100_r_10_gray_200_r_10.xml
+++ b/presentation/mate/src/main/res/drawable/selector_gray_100_r_10_gray_200_r_10.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_checked="true" android:drawable="@drawable/bg_rect_gray_200_border_gray_400_r10" />
+    <item android:state_checkable="false" android:drawable="@drawable/bg_rect_gray100_r10"/>
+</selector>

--- a/presentation/mate/src/main/res/layout/item_connect_habit.xml
+++ b/presentation/mate/src/main/res/layout/item_connect_habit.xml
@@ -10,36 +10,22 @@
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/cl_habit"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:paddingHorizontal="20dp"
-        android:paddingVertical="18dp"
-        android:background="@drawable/bg_rect_gray100_r10">
+        android:layout_height="wrap_content">
 
-        <TextView
-            android:id="@+id/tv_habit_emoji"
-            android:layout_width="wrap_content"
+        <RadioButton
+            android:id="@+id/rb_habit"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:textAppearance="@style/Typography.Body1"
-            android:textColor="@color/gray_700"
-            android:text="@{habitUI.imojiPath}"
+            android:paddingHorizontal="20dp"
+            android:paddingVertical="18dp"
+            android:background="@drawable/selector_gray_100_r_10_gray_200_r_10"
+            android:button="@null"
+            android:text="@{habitUI.imojiPath + `  ` + habitUI.title}"
             app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            tools:text="@string/medicine"/>
+            app:layout_constraintEnd_toEndOf="parent"
+            tools:text="(이모지) 점심직후 비타민"/>
 
-        <TextView
-            android:id="@+id/tv_habit_title"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="8dp"
-            android:textAppearance="@style/Typography.Body1"
-            android:textColor="@color/gray_700"
-            android:text="@{habitUI.title}"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintStart_toEndOf="@+id/tv_habit_emoji"
-            tools:text="@string/habit_sample_title" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>


### PR DESCRIPTION
## 💁‍♂️ 변경 내용

https://user-images.githubusercontent.com/76620764/210120070-98e7b877-9911-4afb-b422-2ea3d05e8922.mp4

### AS-IS
- 두 번 선택해야 습관이 선택되는 효과가 나는 버그가 있었습니다.

### TO-BE
- 정상 작동합니다. (영상 참고)

## 📢 전달사항
- 기존에는 습관이 check 상태를 들고 있으면서 관리하는 형태였는데
지금은 adapter가 관리하게 하였습니다.
또 기존의 텍스트뷰 형식을 버리고 라디오 버튼을 사용했으며
라디오 그룹으로 묶을 수 없기에 adapter가 check 상태를 관리하게 한 것입니다.

- bind 쪽에서 position을 사용하니까 경고가 뜨더라구요.
이 값이 진짜 포지션이라고 여기고 사용하지 말라면서...
아마 빠르게 스크롤 했을 때 사용자에게 보여지는 포지션과 실제 포지션의 딜레이차이 뭐 이런 거 때문에 그런거 아닐까요?...
아무튼 특정 상황이 있나봅니다. 그래서 bindingAdapterPosition을 사용했습니다.