### PR TITLE
fix: 짝꿍 만들기 뒤로가기시 단계 하나만 나가지도록 수정

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -62,15 +62,15 @@
             android:exported="false" />
 
         <activity android:name=".mate.create.step1.ConnectHabitActivity"
-            android:noHistory="true"
+            android:taskAffinity="com.depromeet.threedays.mate"
             android:exported="false" />
 
         <activity android:name=".mate.create.step2.ChooseMateTypeActivity"
-            android:noHistory="true"
+            android:taskAffinity="com.depromeet.threedays.mate"
             android:exported="false" />
 
         <activity android:name=".mate.create.step3.SetMateNicknameActivity"
-            android:noHistory="true"
+            android:taskAffinity="com.depromeet.threedays.mate"
             android:exported="false" />
 
         <activity android:name="com.depromeet.threedays.policy.PolicyActivity"

--- a/presentation/mate/src/main/java/com/depromeet/threedays/mate/MateFragment.kt
+++ b/presentation/mate/src/main/java/com/depromeet/threedays/mate/MateFragment.kt
@@ -70,7 +70,9 @@ class MateFragment: BaseFragment<FragmentMateBinding, MateViewModel>(R.layout.fr
             }
         }
         binding.btnCreateMate.setOnSingleClickListener {
-            startActivity(connectHabitNavigator.intent(requireContext()))
+            val intent = connectHabitNavigator.intent(requireContext())
+            intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
+            startActivity(intent)
         }
         binding.ivShare.setOnSingleClickListener {
             val intent = Intent(requireActivity(), ShareMateActivity::class.java)

--- a/presentation/mate/src/main/java/com/depromeet/threedays/mate/create/step3/SetMateNicknameActivity.kt
+++ b/presentation/mate/src/main/java/com/depromeet/threedays/mate/create/step3/SetMateNicknameActivity.kt
@@ -55,7 +55,7 @@ class SetMateNicknameActivity : BaseActivity<ActivitySetMateNicknameBinding>(R.l
         }
         binding.btnNext.setOnSingleClickListener {
             viewModel.createMate()
-            finish()
+            finishAffinity()
         }
     }
 


### PR DESCRIPTION
## 💁‍♂️ 변경 내용
### AS-IS
- 2단계나 3단계에서 뒤로가기를 누르면 짝꿍 만들기 페이지 (첫 화면으로 이동했습니다)

### TO-BE
- 2단계나 3단계에서 뒤로가기를 누르면 이전 단계로 이동합니다.

## 📢 전달사항
- Affinity를 사용해서 만들기 단계끼리는 새로운 Task영역에서 스택을 관리하도록 했습니다.