### PR TITLE
DEP-333 fix: 짝꿍 없는 상태에서 툴바쪽 아이콘 일부 없애기

### DIFF
--- a/presentation/mate/src/main/res/layout/fragment_mate.xml
+++ b/presentation/mate/src/main/res/layout/fragment_mate.xml
@@ -63,7 +63,7 @@
                 android:id="@+id/group_has_mate"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                app:constraint_referenced_ids="tv_speech_bubble, iv_polygon, tv_level, tv_mate_nickname, tv_start_date, iv_illustration" />
+                app:constraint_referenced_ids="tv_speech_bubble, iv_polygon, tv_level, tv_mate_nickname, tv_start_date, iv_illustration, iv_share, iv_delete, iv_tooltip" />
 
             <androidx.constraintlayout.widget.Group
                 android:id="@+id/group_speech_bubble"


### PR DESCRIPTION
## 💁‍♂️ 변경 내용
### AS-IS
- 짝꿍이 없을 때도 툴팁, 삭제, 공유 버튼이 보였습니다.

### TO-BE
- 짝꿍이 있을때만 버튼이 보입니다.