### PR TITLE
DEP-000 fix: 날짜 포맷 변경

### DIFF
--- a/data/src/main/java/com/depromeet/threedays/data/datasource/achievement/AchievementRemoteDataSource.kt
+++ b/data/src/main/java/com/depromeet/threedays/data/datasource/achievement/AchievementRemoteDataSource.kt
@@ -8,6 +8,6 @@ import java.time.LocalDate
 
 interface AchievementRemoteDataSource {
     suspend fun getHabitAchievements(habitId: Long, from: LocalDate, to: LocalDate): List<AchievementEntity>
-    suspend fun postHabitAchievement(habitId: Long, request: AchievementDateEntity): ApiResponse<HabitEntity>
+    suspend fun postHabitAchievement(habitId: Long, achievementDateEntity: AchievementDateEntity): ApiResponse<HabitEntity>
     suspend fun deleteHabitAchievement(habitId: Long, habitAchievementId: Long): ApiResponse<HabitEntity>
 }

--- a/data/src/main/java/com/depromeet/threedays/data/datasource/achievement/AchievementRemoteDataSourceImpl.kt
+++ b/data/src/main/java/com/depromeet/threedays/data/datasource/achievement/AchievementRemoteDataSourceImpl.kt
@@ -17,9 +17,9 @@ class AchievementRemoteDataSourceImpl @Inject constructor(
 
     override suspend fun postHabitAchievement(
         habitId: Long,
-        request: AchievementDateEntity
+        achievementDateEntity: AchievementDateEntity
     ): ApiResponse<HabitEntity> {
-        return achievementService.postHabitAchievement(habitId = habitId, request = request)
+        return achievementService.postHabitAchievement(habitId = habitId, request = achievementDateEntity)
     }
 
     override suspend fun deleteHabitAchievement(

--- a/data/src/main/java/com/depromeet/threedays/data/entity/achievement/AchievementDateEntity.kt
+++ b/data/src/main/java/com/depromeet/threedays/data/entity/achievement/AchievementDateEntity.kt
@@ -1,5 +1,7 @@
 package com.depromeet.threedays.data.entity.achievement
 
+import java.time.LocalDate
+
 data class AchievementDateEntity(
-    val achievementDate: String
+    val achievementDate: LocalDate,
 )

--- a/data/src/main/java/com/depromeet/threedays/data/repository/AchievementRepositoryImpl.kt
+++ b/data/src/main/java/com/depromeet/threedays/data/repository/AchievementRepositoryImpl.kt
@@ -28,9 +28,11 @@ class AchievementRepositoryImpl @Inject constructor(
 
     override fun createHabitAchievement(habitId: Long): Flow<DataState<Habit>> = flow {
         emit(DataState.loading())
-        val nowDateTime = ZonedDateTime.now(ZoneId.systemDefault())
-        val nowDate = String.format("%d-%d-%d", nowDateTime.year, nowDateTime.monthValue, nowDateTime.dayOfMonth)
-        val response = achievementRemoteDataSource.postHabitAchievement(habitId, AchievementDateEntity(nowDate))
+        val localDate = ZonedDateTime.now(ZoneId.systemDefault()).toLocalDate()
+        val response = achievementRemoteDataSource.postHabitAchievement(
+            habitId  = habitId,
+            achievementDateEntity = AchievementDateEntity(localDate),
+        )
 
         if (response.data != null) {
             emit(DataState.success(data = response.data.toHabit() ))


### PR DESCRIPTION
## 💁‍♂️ 변경 내용
습관 체크 api 요청시 사용하는 날짜 포맷을 개선합니다 

### AS-IS
`%d-%d-%d`  (ex, 2023-1-1)
### TO-BE
`yyyy-MM-dd`  (ex, 2023-01-01)
## 📢 전달사항
