### PR TITLE
DEP-285 fix: 레벨에 맞는 짝궁 이미지 출력

### DIFF
--- a/presentation/mate/src/main/java/com/depromeet/threedays/mate/MateFragment.kt
+++ b/presentation/mate/src/main/java/com/depromeet/threedays/mate/MateFragment.kt
@@ -154,15 +154,7 @@ class MateFragment: BaseFragment<FragmentMateBinding, MateViewModel>(R.layout.fr
             binding.tvLevel.text = getString(R.string.level, it.level)
             binding.tvMateNickname.text = it.title
             binding.tvStartDate.text = getString(R.string.start_date_with_mate, it.createAt.toString().substring(0, 10).replace("-", "."))
-            binding.ivIllustration.setImageResource(
-                when(it.level) {
-                    1 -> core_design.drawable.bg_mate_level_1
-                    2 -> core_design.drawable.bg_mate_level_2
-                    3 -> core_design.drawable.bg_mate_level_3
-                    4 -> core_design.drawable.bg_mate_level_4
-                    else -> core_design.drawable.bg_mate_level_5
-                }
-            )
+            binding.ivIllustration.setImageResource(it.resolveMateImageResource())
 
             val clapCount = it.reward ?: 0
             val maxLevel = it.levelUpSectioin?.last() ?: 22

--- a/presentation/mate/src/main/java/com/depromeet/threedays/mate/MateImageResourceResolver.kt
+++ b/presentation/mate/src/main/java/com/depromeet/threedays/mate/MateImageResourceResolver.kt
@@ -1,0 +1,25 @@
+package com.depromeet.threedays.mate
+
+import com.depromeet.threedays.core_design_system.R
+
+/**
+ * 짝궁 이미지를 선택한다.
+ */
+interface MateImageResourceResolver {
+    fun resolveMateImageResource(): Int
+
+    companion object {
+        /**
+         * 짝궁 Level 을 입력받아서 ResourceId 응답
+         */
+        val levelToResourceFunction: (Int) -> Int = { level: Int ->
+            when (level) {
+                1 -> R.drawable.bg_mate_level_1
+                2 -> R.drawable.bg_mate_level_2
+                3 -> R.drawable.bg_mate_level_3
+                4 -> R.drawable.bg_mate_level_4
+                else -> R.drawable.bg_mate_level_5
+            }
+        }
+    }
+}

--- a/presentation/mate/src/main/java/com/depromeet/threedays/mate/MateImageResourceResolver.kt
+++ b/presentation/mate/src/main/java/com/depromeet/threedays/mate/MateImageResourceResolver.kt
@@ -14,6 +14,8 @@ interface MateImageResourceResolver {
          */
         val levelToResourceFunction: (Int) -> Int = { level: Int ->
             when (level) {
+                // FIXME: 0 레벨 이미지 적용
+                0 -> R.drawable.bg_mate_level_1
                 1 -> R.drawable.bg_mate_level_1
                 2 -> R.drawable.bg_mate_level_2
                 3 -> R.drawable.bg_mate_level_3

--- a/presentation/mate/src/main/java/com/depromeet/threedays/mate/create/step1/model/MateUI.kt
+++ b/presentation/mate/src/main/java/com/depromeet/threedays/mate/create/step1/model/MateUI.kt
@@ -2,6 +2,8 @@ package com.depromeet.threedays.mate.create.step1.model
 
 import com.depromeet.threedays.domain.entity.mate.Mate
 import com.depromeet.threedays.domain.entity.mate.MateType
+import com.depromeet.threedays.mate.MateImageResourceResolver
+import com.depromeet.threedays.mate.MateImageResourceResolver.Companion.levelToResourceFunction
 import java.time.LocalDateTime
 
 data class MateUI(
@@ -18,10 +20,14 @@ data class MateUI(
     val levelUpSectioin: List<Int>?,
     val bubble: String,
     val status: String,
-) {
+) : MateImageResourceResolver {
     data class RewardHistoryUI(
         val createAt: LocalDateTime,
     )
+
+    override fun resolveMateImageResource(): Int {
+        return levelToResourceFunction(level)
+    }
 }
 
 fun Mate.toMateUI(): MateUI {

--- a/presentation/mate/src/main/java/com/depromeet/threedays/mate/share/ShareMateActivity.kt
+++ b/presentation/mate/src/main/java/com/depromeet/threedays/mate/share/ShareMateActivity.kt
@@ -16,6 +16,7 @@ import com.depromeet.threedays.core.BaseActivity
 import com.depromeet.threedays.core.setOnSingleClickListener
 import com.depromeet.threedays.core.util.ThreeDaysToast
 import com.depromeet.threedays.mate.R
+import com.depromeet.threedays.mate.create.step1.model.toMateUI
 import com.depromeet.threedays.mate.databinding.ActivityShareMateBinding
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
@@ -27,13 +28,6 @@ import java.util.*
 @AndroidEntryPoint
 class ShareMateActivity : BaseActivity<ActivityShareMateBinding>(R.layout.activity_share_mate) {
     private val viewModel by viewModels<ShareMateViewModel>()
-    val mates = listOf(
-        com.depromeet.threedays.core_design_system.R.drawable.bg_mate_level_1,
-        com.depromeet.threedays.core_design_system.R.drawable.bg_mate_level_2,
-        com.depromeet.threedays.core_design_system.R.drawable.bg_mate_level_3,
-        com.depromeet.threedays.core_design_system.R.drawable.bg_mate_level_4,
-        com.depromeet.threedays.core_design_system.R.drawable.bg_mate_level_5,
-    )
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -57,12 +51,12 @@ class ShareMateActivity : BaseActivity<ActivityShareMateBinding>(R.layout.activi
         lifecycleScope.launch {
             lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 viewModel.uiState.collect {
-                    if(it.singleHabit != null) {
+                    if (it.singleHabit != null) {
                         binding.singleHabit = it.singleHabit
-                        val mateLevel = it.singleHabit.mate?.level ?: 1
-                        binding.ivMate.setImageResource(
-                            mates[mateLevel - 1]
-                        )
+                        it.singleHabit.mate?.run {
+                            val mageImageResourceId = this.toMateUI().resolveMateImageResource()
+                            binding.ivMate.setImageResource(mageImageResourceId)
+                        }
                     }
                     setScreenShotBackgroundColor(it.backgroundResId)
                 }

--- a/presentation/mypage/build.gradle
+++ b/presentation/mypage/build.gradle
@@ -45,6 +45,7 @@ dependencies {
     implementation(project(":core-design-system"))
     implementation(project(":navigator"))
     implementation(project(":domain"))
+    implementation(project(":presentation:mate"))
 
     implementation(jetpackDeps)
     implementation(coroutines)

--- a/presentation/mypage/src/main/java/com/depromeet/threedays/mypage/archived_habit/ArchivedHabitActivity.kt
+++ b/presentation/mypage/src/main/java/com/depromeet/threedays/mypage/archived_habit/ArchivedHabitActivity.kt
@@ -38,7 +38,7 @@ class ArchivedHabitActivity :
             openMateDialogFunction = {
                 ThreeDaysOneButtonDialogFragment.newInstance(
                     data = OneButtonDialogInfo(
-                        resId = com.depromeet.threedays.core_design_system.R.drawable.bg_mate_level_1,
+                        resId = it.resolveMateImageResource(),
                         level = it.level,
                         title = it.nickname,
                         description = it.getLevelDescription(),

--- a/presentation/mypage/src/main/java/com/depromeet/threedays/mypage/archived_habit/ArchivedHabitViewHolder.kt
+++ b/presentation/mypage/src/main/java/com/depromeet/threedays/mypage/archived_habit/ArchivedHabitViewHolder.kt
@@ -46,6 +46,7 @@ class ArchivedHabitViewHolder(
             with(archivedHabitUI.mate!!) {
                 binding.tvMateNickname.text = nickname
                 binding.tvMateLevelDescription.text = getLevelDescription()
+                binding.ivMateProfileImage.setImageResource(resolveMateImageResource())
             }
         } else {
             binding.clMateOpened.gone()

--- a/presentation/mypage/src/main/java/com/depromeet/threedays/mypage/archived_habit/archived_mate/ArchivedMateUI.kt
+++ b/presentation/mypage/src/main/java/com/depromeet/threedays/mypage/archived_habit/archived_mate/ArchivedMateUI.kt
@@ -1,13 +1,14 @@
 package com.depromeet.threedays.mypage.archived_habit.archived_mate
 
 import com.depromeet.threedays.domain.entity.mate.Mate
+import com.depromeet.threedays.mate.MateImageResourceResolver
 
 data class ArchivedMateUI(
     val mateId: Long,
     val habitId: Long,
     val nickname: String,
     val level: Int,
-) {
+) : MateImageResourceResolver {
     companion object {
         fun from(mate: Mate) = ArchivedMateUI(
             mateId = mate.id,
@@ -18,4 +19,10 @@ data class ArchivedMateUI(
     }
 
     fun getLevelDescription() = "Lv.${level}까지 진화"
+
+    /**
+     * 짝궁 레벨에 맞는 resource id
+     */
+    override fun resolveMateImageResource() =
+        MateImageResourceResolver.levelToResourceFunction(level)
 }


### PR DESCRIPTION
## 💁‍♂️ 변경 내용
### AS-IS
- 레벨1 짝궁 하드코딩, 기본이미지 사용
### TO-BE
- 레벨에 맞는 짝궁 이미지 출력
## 📢 전달사항
- 중복코드 제거하고싶었는데, mypage 모듈이 mate 를 의존하게되어서 좀 슬프네요.. ㅠㅠ 나중에 페이지랑 모델도 레이어를 잘 나누는 식으로 리팩터링 해보곘습니다