### PR TITLE
DEP-337 fix: 캘린더에서 이전 월로 넘어가지 않는 오류 해결 및 스크롤 시 이벤트 재설정

### DIFF
--- a/presentation/history/src/main/java/com/depromeet/threedays/history/detail/DetailHistoryActivity.kt
+++ b/presentation/history/src/main/java/com/depromeet/threedays/history/detail/DetailHistoryActivity.kt
@@ -22,7 +22,6 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import java.time.LocalDate
 import java.time.YearMonth
-import java.time.temporal.ChronoUnit
 import java.time.temporal.WeekFields
 import java.util.*
 import com.depromeet.threedays.core_design_system.R as designR
@@ -107,20 +106,16 @@ class DetailHistoryActivity :
                         binding.tvAchievementDayCountOfMonth.text = String.format(getString(R.string.month_achievement_day_count), currentCalendarDate.monthValue, currentMonthStatic.achievements)
 
                         if(!isOnlyListChanged) {
-                            firstMonth = immutableCurrentMonth.minusMonths(
-                                ChronoUnit.MONTHS.between(
-                                    habit.createAt,
-                                    state.today
-                                )
-                            ).also {
-                                binding.ivPrevious.isEnabled = (immutableCurrentMonth != it)
+                            firstMonth = YearMonth.of(habit.createAt.year, habit.createAt.monthValue)
+                            .also { firstMonth ->
+                                binding.ivPrevious.isEnabled = (immutableCurrentMonth != firstMonth)
                             }
 
                             initCalendar(
                                 color = habit.color,
                                 dateList = achievementDateWithStatusList,
                                 firstMonth = firstMonth,
-                                lastMonth = immutableCurrentMonth.plusMonths(0)
+                                lastMonth = immutableCurrentMonth
                             )
                             viewModel.setIsOnlyListChanged(true)
                         }

--- a/presentation/history/src/main/java/com/depromeet/threedays/history/detail/DetailHistoryActivity.kt
+++ b/presentation/history/src/main/java/com/depromeet/threedays/history/detail/DetailHistoryActivity.kt
@@ -52,36 +52,17 @@ class DetailHistoryActivity :
 
     private fun initView() {
         binding.ivPrevious.setOnSingleClickListener {
-            binding.cvHistory.findFirstVisibleMonth()?.let {
-                binding.cvHistory.smoothScrollToMonth(it.yearMonth.previousMonth)
-                binding.tvToday.text = String.format(
-                    "%d년 %02d월",
-                    it.yearMonth.previousMonth.year,
-                    it.yearMonth.previousMonth.monthValue
-                )
-                viewModel.setCurrentCalendarDate(it.yearMonth.previousMonth.atDay(viewModel.state.value.today.dayOfMonth))
-                viewModel.getHabitAchievementDateList(viewModel.habitId)
-
-                binding.ivPrevious.isEnabled = (firstMonth != it.yearMonth.previousMonth)
-                binding.ivNext.isEnabled = (immutableCurrentMonth != it.yearMonth.previousMonth)
+            binding.cvHistory.findFirstVisibleMonth()?.let { calendarMonth ->
+                binding.cvHistory.smoothScrollToMonth(calendarMonth.yearMonth.previousMonth)
+                onCalendarMonthMoved(calendarMonth.yearMonth.nextMonth)
             }
         }
 
         binding.ivNext.isEnabled = false
         binding.ivNext.setOnSingleClickListener {
-            binding.cvHistory.findFirstVisibleMonth()?.let {
-                binding.cvHistory.smoothScrollToMonth(it.yearMonth.nextMonth)
-                binding.tvToday.text = String.format(
-                    "%d년 %02d월",
-                    it.yearMonth.nextMonth.year,
-                    it.yearMonth.nextMonth.monthValue
-                )
-
-                viewModel.setCurrentCalendarDate(it.yearMonth.nextMonth.atDay(viewModel.state.value.today.dayOfMonth))
-                viewModel.getHabitAchievementDateList(viewModel.habitId)
-
-                binding.ivPrevious.isEnabled = (firstMonth != it.yearMonth.nextMonth)
-                binding.ivNext.isEnabled = (immutableCurrentMonth != it.yearMonth.nextMonth)
+            binding.cvHistory.findFirstVisibleMonth()?.let { calendarMonth ->
+                binding.cvHistory.smoothScrollToMonth(calendarMonth.yearMonth.nextMonth)
+                onCalendarMonthMoved(calendarMonth.yearMonth.nextMonth)
             }
         }
 
@@ -143,17 +124,25 @@ class DetailHistoryActivity :
             cvHistory.dayBinder = DayBind.newInstance(dateList, color)
             cvHistory.setup(firstMonth, lastMonth, firstDayOfWeek)
             cvHistory.scrollToMonth(immutableCurrentMonth)
-            cvHistory.monthScrollListener = { calendar ->
-                binding.tvToday.text = String.format(
-                    "%d년 %02d월",
-                    calendar.yearMonth.year,
-                    calendar.yearMonth.monthValue
-                )
+            cvHistory.monthScrollListener = { calendarMonth ->
+                onCalendarMonthMoved(calendarMonth.yearMonth)
             }
         }
     }
 
+    private fun onCalendarMonthMoved(now: YearMonth) {
+        binding.tvToday.text = String.format(
+            "%d년 %02d월",
+            now.year,
+            now.monthValue
+        )
 
+        viewModel.setCurrentCalendarDate(now.atDay(viewModel.state.value.today.dayOfMonth))
+        viewModel.getHabitAchievementDateList(viewModel.habitId)
+
+        binding.ivPrevious.isEnabled = (firstMonth != now)
+        binding.ivNext.isEnabled = (immutableCurrentMonth != now)
+    }
 
     private fun setColorView(color: Color) {
         val habitColor = this.getHabitColor(color)


### PR DESCRIPTION
## 💁‍♂️ 변경 내용
### AS-IS
- 캘린더에서 이전 월로 넘어가지 않았습니다
- 캘린더 스크롤 시 데이터를 새로 불러오지 않았고, 월별 통계가 표시되지 않았으며 캘린더 이동 버튼의 `enable`처리가 되지 않았습니다.

### TO-BE
- 캘린더의 `firstMonth` 설정을 생성일로 하여 생성 월까지 넘어갈 수 있도록 하였습니다.
- 캘린더 스크롤 시 데이터를 새로 불러오고, 월별 통계가 표시되며 캘린더 이동 버튼의 `enable`처리가 됩니다

## 📢 전달사항
