### PR TITLE
DEP-340 fix: 스플래시 온보딩 스택에 쌓이지 않도록 수정

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -55,6 +55,7 @@
 
         <activity
             android:name="com.depromeet.threedays.onboarding.OnboardingActivity"
+            android:noHistory="true"
             android:exported="false" />
 
         <activity


### PR DESCRIPTION
## 💁‍♂️ 변경 내용
### AS-IS
- 온보딩 이후 뒤로가기하면 다시 온보딩 페이지로 이동했습니다.

### TO-BE
- 온보딩 페이지가 스택에 쌓이지 않게 했습니다. (뒤로가기 하면 앱 그냥 종료)

## 📢 전달사항
