### PR TITLE
DEP-341 fix: bottom navigation text 사이즈 조정

### DIFF
--- a/core-design-system/src/main/res/values/themes.xml
+++ b/core-design-system/src/main/res/values/themes.xml
@@ -30,4 +30,12 @@
         <item name="android:textColorPrimary">@color/gray_800</item>
         <item name="android:textAppearance">@style/Typography.Body1</item>
     </style>
+
+    <style name="BottomNavigationView" parent="@style/TextAppearance.AppCompat.Caption">
+        <item name="android:textSize">11sp</item>
+    </style>
+
+    <style name="BottomNavigationView.Active" parent="@style/TextAppearance.AppCompat.Caption">
+        <item name="android:textSize">11sp</item>
+    </style>
 </resources>

--- a/presentation/home/src/main/res/layout/activity_main.xml
+++ b/presentation/home/src/main/res/layout/activity_main.xml
@@ -29,6 +29,8 @@
             android:id="@+id/bnv_main"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            app:itemTextAppearanceActive="@style/BottomNavigationView.Active"
+            app:itemTextAppearanceInactive="@style/BottomNavigationView"
             app:labelVisibilityMode="labeled"
             app:elevation="0dp"
             app:itemIconTint="@drawable/selector_menu_color"


### PR DESCRIPTION
## 💁‍♂️ 변경 내용
### AS-IS
- bottom navigation text 사이즈가 기본값이였습니다.

### TO-BE
- 피그마에 맞게 변경했습니다

## 📢 전달사항
