### PR TITLE
DEP-346 feat: 알림 권유 바텀 시트 구현

### DIFF
--- a/domain/src/main/java/com/depromeet/threedays/domain/entity/OnboardingType.kt
+++ b/domain/src/main/java/com/depromeet/threedays/domain/entity/OnboardingType.kt
@@ -1,0 +1,7 @@
+package com.depromeet.threedays.domain.entity
+
+enum class OnboardingType(val key: String) {
+    NOTIFICATION_RECOMMEND("NOTIFICATION_RECOMMEND"),
+    AFTER_SPLASH("AFTER_SPLASH"),
+    MATE("MATE"),
+}

--- a/domain/src/main/java/com/depromeet/threedays/domain/usecase/onboarding/ReadOnboardingUseCase.kt
+++ b/domain/src/main/java/com/depromeet/threedays/domain/usecase/onboarding/ReadOnboardingUseCase.kt
@@ -1,8 +1,17 @@
 package com.depromeet.threedays.domain.usecase.onboarding
 
+import com.depromeet.threedays.domain.entity.OnboardingType
 import com.depromeet.threedays.domain.repository.OnboardingRepository
 import javax.inject.Inject
 
 class ReadOnboardingUseCase @Inject constructor(val repository: OnboardingRepository) {
-    suspend fun execute(key: String): String? = repository.readOnboardnig(key)
+    suspend fun execute(onboardingType: OnboardingType): String? {
+        val key = when (onboardingType) {
+            OnboardingType.NOTIFICATION_RECOMMEND -> OnboardingType.NOTIFICATION_RECOMMEND.key
+            OnboardingType.AFTER_SPLASH -> OnboardingType.AFTER_SPLASH.key
+            OnboardingType.MATE -> OnboardingType.MATE.key
+        }
+        return repository.readOnboardnig(key)
+    }
 }
+

--- a/domain/src/main/java/com/depromeet/threedays/domain/usecase/onboarding/WriteOnboardingUseCase.kt
+++ b/domain/src/main/java/com/depromeet/threedays/domain/usecase/onboarding/WriteOnboardingUseCase.kt
@@ -1,8 +1,16 @@
 package com.depromeet.threedays.domain.usecase.onboarding
 
+import com.depromeet.threedays.domain.entity.OnboardingType
 import com.depromeet.threedays.domain.repository.OnboardingRepository
 import javax.inject.Inject
 
 class WriteOnboardingUseCase @Inject constructor(val repository: OnboardingRepository) {
-    suspend fun execute(key: String, value: String) = repository.writeOnboardnig(key = key, value = value)
+    suspend fun execute(onboardingType: OnboardingType) {
+        val key = when (onboardingType) {
+            OnboardingType.NOTIFICATION_RECOMMEND -> OnboardingType.NOTIFICATION_RECOMMEND.key
+            OnboardingType.AFTER_SPLASH -> OnboardingType.AFTER_SPLASH.key
+            OnboardingType.MATE -> OnboardingType.MATE.key
+        }
+        return repository.writeOnboardnig(key = key, value = "IS_SHWON")
+    }
 }

--- a/presentation/home/src/main/java/com/depromeet/threedays/home/home/HomeFragment.kt
+++ b/presentation/home/src/main/java/com/depromeet/threedays/home/home/HomeFragment.kt
@@ -8,6 +8,7 @@ import android.provider.Settings
 import android.view.View
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.app.NotificationManagerCompat
+import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
@@ -23,9 +24,11 @@ import com.depromeet.threedays.domain.key.RESULT_CREATE
 import com.depromeet.threedays.domain.key.RESULT_UPDATE
 import com.depromeet.threedays.home.MainActivity
 import com.depromeet.threedays.home.R
+import com.depromeet.threedays.core_design_system.R as core_design
 import com.depromeet.threedays.home.databinding.FragmentHomeBinding
 import com.depromeet.threedays.home.home.dialog.MoreActionModal
 import com.depromeet.threedays.home.home.dialog.NotiGuideBottomSheet
+import com.depromeet.threedays.home.home.dialog.NotiRecommendBottomSheet
 import com.depromeet.threedays.navigator.ArchivedHabitNavigator
 import com.depromeet.threedays.navigator.HabitCreateNavigator
 import com.depromeet.threedays.navigator.HabitUpdateNavigator
@@ -70,6 +73,7 @@ class HomeFragment : BaseFragment<FragmentHomeBinding, HomeViewModel>(R.layout.f
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
+        viewModel.checkIsFirstVisitor()
         checkNotificationPermission()
         initAdapter()
         setObserve()
@@ -193,11 +197,19 @@ class HomeFragment : BaseFragment<FragmentHomeBinding, HomeViewModel>(R.layout.f
         )
     }
 
-    private fun showNotiGuideBottomSheet(isDeviceNotificationOn: Boolean) {
-        if(isDeviceNotificationOn.not()) {
+    private fun showBottomSheet(
+        isDeviceNotificationOn: Boolean,
+        isFirstVisitor: Boolean,
+    ) {
+        if(!isDeviceNotificationOn) {
             NotiGuideBottomSheet.newInstance (
                 moveToSettingForTurnOnPermission = { moveToSettingForTurnOnPermission() }
             ).show(parentFragmentManager, NotiGuideBottomSheet.TAG)
+        }
+        if(isFirstVisitor) {
+            val modal = NotiRecommendBottomSheet()
+            modal.setStyle(DialogFragment.STYLE_NORMAL, core_design.style.RoundCornerBottomSheetDialogTheme)
+            modal.show(parentFragmentManager, NotiGuideBottomSheet.TAG)
         }
     }
 
@@ -220,7 +232,10 @@ class HomeFragment : BaseFragment<FragmentHomeBinding, HomeViewModel>(R.layout.f
                 }
                 launch {
                     viewModel.uiState.collect {
-                        showNotiGuideBottomSheet(isDeviceNotificationOn = it.isDeviceNotificationOn)
+                        showBottomSheet(
+                            isDeviceNotificationOn = it.isDeviceNotificationOn,
+                            isFirstVisitor = it.isFirstVisitor,
+                        )
                     }
                 }
                 launch {

--- a/presentation/mate/src/main/java/com/depromeet/threedays/mate/MateViewModel.kt
+++ b/presentation/mate/src/main/java/com/depromeet/threedays/mate/MateViewModel.kt
@@ -3,6 +3,7 @@ package com.depromeet.threedays.mate
 import androidx.lifecycle.viewModelScope
 import com.depromeet.threedays.core.BaseViewModel
 import com.depromeet.threedays.domain.entity.Color
+import com.depromeet.threedays.domain.entity.OnboardingType
 import com.depromeet.threedays.domain.entity.Status
 import com.depromeet.threedays.domain.entity.habit.SingleHabit
 import com.depromeet.threedays.domain.repository.HabitRepository
@@ -104,9 +105,9 @@ class MateViewModel @Inject constructor(
     private fun checkIsFirstVisitor() {
         viewModelScope.launch {
             if (isFirstVisitor.value.not()) {
-                val response = readOnboardingUseCase.execute(IS_FIRST_VISIT_ONBOARDING_MATE)
+                val response = readOnboardingUseCase.execute(OnboardingType.MATE)
                 _isFirstVisitor.update {
-                    response == null || response == "true"
+                    response == null
                 }
             }
         }
@@ -114,7 +115,7 @@ class MateViewModel @Inject constructor(
 
     fun writeIsFirstVisitor() {
         viewModelScope.launch {
-            writeOnboardingUseCase.execute(IS_FIRST_VISIT_ONBOARDING_MATE, "false")
+            writeOnboardingUseCase.execute(OnboardingType.MATE)
         }
     }
 
@@ -217,7 +218,6 @@ class MateViewModel @Inject constructor(
     }
 
     companion object {
-        private const val IS_FIRST_VISIT_ONBOARDING_MATE = "IS_FIRST_VISIT_ONBOARDING_MATE"
         private const val MATE_MAX_CLAP = 22
         private const val KEY_MAX_LEVEL_DIALOG_SHOWN = "KEY_MAX_LEVEL_DIALOG_SHOWN"
     }

--- a/presentation/onboarding/src/main/java/com/depromeet/threedays/onboarding/OnboardingViewModel.kt
+++ b/presentation/onboarding/src/main/java/com/depromeet/threedays/onboarding/OnboardingViewModel.kt
@@ -2,6 +2,7 @@ package com.depromeet.threedays.onboarding
 
 import androidx.lifecycle.viewModelScope
 import com.depromeet.threedays.core.BaseViewModel
+import com.depromeet.threedays.domain.entity.OnboardingType
 import com.depromeet.threedays.domain.usecase.onboarding.WriteOnboardingUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
@@ -13,11 +14,7 @@ class OnboardingViewModel @Inject constructor(
 ) : BaseViewModel() {
     fun writeIsFirstVisitor() {
         viewModelScope.launch {
-            writeOnboardingUseCase.execute(IS_FIRST_VISIT_ONBOARDING_AFTER_SPLASH, "false")
+            writeOnboardingUseCase.execute(OnboardingType.AFTER_SPLASH)
         }
-    }
-
-    companion object {
-        private const val IS_FIRST_VISIT_ONBOARDING_AFTER_SPLASH = "IS_FIRST_VISIT_ONBOARDING_AFTER_SPLASH"
     }
 }

--- a/presentation/splash/src/main/java/com/depromeet/threedays/splash/SplashViewModel.kt
+++ b/presentation/splash/src/main/java/com/depromeet/threedays/splash/SplashViewModel.kt
@@ -3,6 +3,7 @@ package com.depromeet.threedays.splash
 import com.depromeet.threedays.domain.repository.AuthRepository
 import androidx.lifecycle.viewModelScope
 import com.depromeet.threedays.core.BaseViewModel
+import com.depromeet.threedays.domain.entity.OnboardingType
 import com.depromeet.threedays.domain.usecase.onboarding.ReadOnboardingUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -27,18 +28,14 @@ class SplashViewModel @Inject constructor(
 
     private fun checkIsFirstVisitor() {
         viewModelScope.launch {
-            val response = readOnboardingUseCase.execute(IS_FIRST_VISIT_ONBOARDING_AFTER_SPLASH)
+            val response = readOnboardingUseCase.execute(OnboardingType.AFTER_SPLASH)
             _isFirstVisitor.update {
-                (response == null || response == "true")
+                response == null
             }
         }
     }
     
     fun isSignedUp(): Boolean {
         return authRepository.getAccessTokenFromLocal().isNotEmpty()
-    }
-
-    companion object {
-        private const val IS_FIRST_VISIT_ONBOARDING_AFTER_SPLASH = "IS_FIRST_VISIT_ONBOARDING_AFTER_SPLASH"
     }
 }


### PR DESCRIPTION
## 💁‍♂️ 변경 내용
### AS-IS
- 알림권유 바텀시트가 뜨지 않았습니다.
- 온보딩 key 관리를 사용하는 곳(viewModel)에서 관리했습니다.
- datastore 사용시 viewModel에서 usecase에게 key를 직접 넘겨주었습니다.

### TO-BE
- 앱 첫 방문시 알림 권유 바텀시트가 뜹니다.
- 온보딩 key 관리를 usecase에서 관리합니다.
- datastore 사용시 viewModel에서 onboardingType을 넘겨 주어 usecase가 key를 선택하도록 합니다.