### PR TITLE
DEP-357 feat: 회원가입 성공시 fcm token 등록

### DIFF
--- a/app/src/main/java/com/depromeet/threedays/firebase/FCMService.kt
+++ b/app/src/main/java/com/depromeet/threedays/firebase/FCMService.kt
@@ -9,16 +9,34 @@ import android.content.Intent
 import android.os.Build
 import android.util.Log
 import androidx.core.app.NotificationCompat
+import com.depromeet.threedays.domain.usecase.notification.token.UpdateNotificationTokenUseCase
 import com.depromeet.threedays.home.MainActivity
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
+import kotlinx.coroutines.runBlocking
+import timber.log.Timber
+import javax.inject.Inject
 import com.depromeet.threedays.core_design_system.R as CoreDesignSystemResources
 
-class FCMService : FirebaseMessagingService() {
+class FCMService @Inject constructor() : FirebaseMessagingService() {
+    @Inject
+    lateinit var updateNotificationTokenUseCase: UpdateNotificationTokenUseCase
 
     override fun onNewToken(token: String) {
         super.onNewToken(token)
         Log.i(TAG, "onNewToken: $token")
+        try {
+            // FIXME:
+            //  - useCase initialize 안되었다는 에러 발생함.
+            //  - 앱 처음 설치하면 스플래시 화면에서 호출되는데 이 때 memberId 없음
+            runBlocking {
+                updateNotificationTokenUseCase(token)
+            }
+        } catch (e: Exception) {
+            Timber.w(
+                e, "Failed to update fcm registration token"
+            )
+        }
     }
 
     override fun onMessageReceived(message: RemoteMessage) {

--- a/app/src/main/java/com/depromeet/threedays/firebase/FirebaseModule.kt
+++ b/app/src/main/java/com/depromeet/threedays/firebase/FirebaseModule.kt
@@ -1,5 +1,6 @@
 package com.depromeet.threedays.firebase
 
+import com.depromeet.threedays.data.datasource.notification.token.NotificationTokenLocalDataSource
 import com.google.firebase.messaging.FirebaseMessaging
 import dagger.Module
 import dagger.Provides
@@ -14,4 +15,10 @@ object FirebaseModule {
     @Singleton
     @Provides
     fun bindsFirebaseMessagingProvide(): FirebaseMessaging = FirebaseMessaging.getInstance()
+
+    @Singleton
+    @Provides
+    fun bindsFirebaseTokenDataSourceProvide(
+        firebaseTokenDataSource: FirebaseTokenDataSource
+    ): NotificationTokenLocalDataSource = firebaseTokenDataSource
 }

--- a/app/src/main/java/com/depromeet/threedays/firebase/FirebaseTokenDataSource.kt
+++ b/app/src/main/java/com/depromeet/threedays/firebase/FirebaseTokenDataSource.kt
@@ -1,0 +1,22 @@
+package com.depromeet.threedays.firebase
+
+import com.depromeet.threedays.data.datasource.notification.token.NotificationTokenLocalDataSource
+import com.google.firebase.messaging.FirebaseMessaging
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.tasks.await
+import timber.log.Timber
+import javax.inject.Inject
+
+class FirebaseTokenDataSource @Inject constructor() : NotificationTokenLocalDataSource {
+    override suspend fun getToken(): String? {
+        val registrationToken = runBlocking {
+            FirebaseMessaging.getInstance().token
+                .addOnCompleteListener {
+                    if (!it.isSuccessful) {
+                        Timber.e("Failed to get registration token")
+                    }
+                }.await()
+        }
+        return registrationToken
+    }
+}

--- a/data/src/main/java/com/depromeet/threedays/data/api/NotificationTokenService.kt
+++ b/data/src/main/java/com/depromeet/threedays/data/api/NotificationTokenService.kt
@@ -1,0 +1,17 @@
+package com.depromeet.threedays.data.api
+
+import com.depromeet.threedays.data.entity.base.ApiResponse
+import com.depromeet.threedays.data.entity.notification.NotificationTokenRequest
+import com.depromeet.threedays.data.entity.record.RecordEntity
+import retrofit2.http.Body
+import retrofit2.http.POST
+
+interface NotificationTokenService {
+    /**
+     * fcm 토큰 등록
+     */
+    @POST("/api/v1/clients")
+    suspend fun updateToken(
+        @Body notificationTokenRequest: NotificationTokenRequest,
+    ): ApiResponse<RecordEntity>
+}

--- a/data/src/main/java/com/depromeet/threedays/data/datasource/notification/history/NotificationHistoryRemoteDataSource.kt
+++ b/data/src/main/java/com/depromeet/threedays/data/datasource/notification/history/NotificationHistoryRemoteDataSource.kt
@@ -1,4 +1,4 @@
-package com.depromeet.threedays.data.datasource.notification
+package com.depromeet.threedays.data.datasource.notification.history
 
 import com.depromeet.threedays.data.entity.notification.NotificationHistoryEntity
 import com.depromeet.threedays.domain.entity.notification.NotificationHistoryStatus

--- a/data/src/main/java/com/depromeet/threedays/data/datasource/notification/history/NotificationHistoryRemoteDataSourceImpl.kt
+++ b/data/src/main/java/com/depromeet/threedays/data/datasource/notification/history/NotificationHistoryRemoteDataSourceImpl.kt
@@ -1,4 +1,4 @@
-package com.depromeet.threedays.data.datasource.notification
+package com.depromeet.threedays.data.datasource.notification.history
 
 import com.depromeet.threedays.data.api.NotificationHistoryService
 import com.depromeet.threedays.data.entity.notification.NotificationHistoryEntity

--- a/data/src/main/java/com/depromeet/threedays/data/datasource/notification/token/NotificationTokenLocalDataSource.kt
+++ b/data/src/main/java/com/depromeet/threedays/data/datasource/notification/token/NotificationTokenLocalDataSource.kt
@@ -1,0 +1,5 @@
+package com.depromeet.threedays.data.datasource.notification.token
+
+interface NotificationTokenLocalDataSource {
+    suspend fun getToken(): String?
+}

--- a/data/src/main/java/com/depromeet/threedays/data/datasource/notification/token/NotificationTokenRemoteDataSource.kt
+++ b/data/src/main/java/com/depromeet/threedays/data/datasource/notification/token/NotificationTokenRemoteDataSource.kt
@@ -1,0 +1,9 @@
+package com.depromeet.threedays.data.datasource.notification.token
+
+import com.depromeet.threedays.data.entity.notification.NotificationTokenRequest
+
+interface NotificationTokenRemoteDataSource {
+    suspend fun updateToken(
+        notificationTokenRequest: NotificationTokenRequest,
+    )
+}

--- a/data/src/main/java/com/depromeet/threedays/data/datasource/notification/token/NotificationTokenRemoteDataSourceImpl.kt
+++ b/data/src/main/java/com/depromeet/threedays/data/datasource/notification/token/NotificationTokenRemoteDataSourceImpl.kt
@@ -1,0 +1,25 @@
+package com.depromeet.threedays.data.datasource.notification.token
+
+import com.depromeet.threedays.data.api.NotificationTokenService
+import com.depromeet.threedays.data.entity.notification.NotificationTokenRequest
+import timber.log.Timber
+import javax.inject.Inject
+
+class NotificationTokenRemoteDataSourceImpl @Inject constructor(
+    private val notificationTokenService: NotificationTokenService,
+) : NotificationTokenRemoteDataSource {
+    override suspend fun updateToken(
+        notificationTokenRequest: NotificationTokenRequest,
+    ) {
+        try {
+            notificationTokenService.updateToken(
+                notificationTokenRequest = notificationTokenRequest,
+            )
+        } catch (e: Exception) {
+            Timber.e(
+                e,
+                "Failed to register fcmToken. notificationTokenRequest: $notificationTokenRequest"
+            )
+        }
+    }
+}

--- a/data/src/main/java/com/depromeet/threedays/data/di/RemoteModule.kt
+++ b/data/src/main/java/com/depromeet/threedays/data/di/RemoteModule.kt
@@ -10,8 +10,10 @@ import com.depromeet.threedays.data.datasource.mate.MateRemoteDataSource
 import com.depromeet.threedays.data.datasource.mate.MateRemoteDataSourceImpl
 import com.depromeet.threedays.data.datasource.member.MemberRemoteDataSource
 import com.depromeet.threedays.data.datasource.member.MemberRemoteDataSourceImpl
-import com.depromeet.threedays.data.datasource.notification.NotificationHistoryRemoteDataSource
-import com.depromeet.threedays.data.datasource.notification.NotificationHistoryRemoteDataSourceImpl
+import com.depromeet.threedays.data.datasource.notification.history.NotificationHistoryRemoteDataSource
+import com.depromeet.threedays.data.datasource.notification.history.NotificationHistoryRemoteDataSourceImpl
+import com.depromeet.threedays.data.datasource.notification.token.NotificationTokenRemoteDataSource
+import com.depromeet.threedays.data.datasource.notification.token.NotificationTokenRemoteDataSourceImpl
 import com.depromeet.threedays.data.datasource.record.RecordRemoteDataSource
 import com.depromeet.threedays.data.datasource.record.RecordRemoteDataSourceImpl
 import dagger.Binds
@@ -65,4 +67,10 @@ internal abstract class RemoteModule {
     abstract fun bindRecordRemoteDataSource(
         dataSource: RecordRemoteDataSourceImpl,
     ): RecordRemoteDataSource
+
+    @Binds
+    @Singleton
+    abstract fun bindNotificationTokenRemoteDataSource(
+        dataSource: NotificationTokenRemoteDataSourceImpl,
+    ): NotificationTokenRemoteDataSource
 }

--- a/data/src/main/java/com/depromeet/threedays/data/di/RepositoryModule.kt
+++ b/data/src/main/java/com/depromeet/threedays/data/di/RepositoryModule.kt
@@ -11,7 +11,6 @@ import javax.inject.Singleton
 @Module
 @InstallIn(SingletonComponent::class)
 abstract class RepositoryModule {
-    // DataStore
     @Binds
     @Singleton
     abstract fun bindsNotificationPermissionRepository(
@@ -72,4 +71,16 @@ abstract class RepositoryModule {
     abstract fun bindsRecordRepository(
         repository: RecordRepositoryImpl,
     ): RecordRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindsNotificationTokenRepository(
+        repository: NotificationTokenRepositoryImpl,
+    ): NotificationTokenRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindsDeviceUniqueIdRepository(
+        repository: DeviceUniqueIdRepositoryImpl,
+    ): DeviceUniqueIdRepository
 }

--- a/data/src/main/java/com/depromeet/threedays/data/di/ServiceModule.kt
+++ b/data/src/main/java/com/depromeet/threedays/data/di/ServiceModule.kt
@@ -77,6 +77,12 @@ class NetworkModule {
 
     @Provides
     @Singleton
+    fun providesNotificationTokenService(
+        retrofit: Retrofit,
+    ): NotificationTokenService = retrofit.create()
+
+    @Provides
+    @Singleton
     fun providesHttpClient(
         @ApplicationContext context: Context,
         gson: Gson,

--- a/data/src/main/java/com/depromeet/threedays/data/entity/notification/NotificationTokenRequest.kt
+++ b/data/src/main/java/com/depromeet/threedays/data/entity/notification/NotificationTokenRequest.kt
@@ -1,0 +1,6 @@
+package com.depromeet.threedays.data.entity.notification
+
+data class NotificationTokenRequest(
+    val fcmToken: String,
+    val identificationKey: String,
+)

--- a/data/src/main/java/com/depromeet/threedays/data/entity/notification/NotificationTokenResponse.kt
+++ b/data/src/main/java/com/depromeet/threedays/data/entity/notification/NotificationTokenResponse.kt
@@ -1,0 +1,8 @@
+package com.depromeet.threedays.data.entity.notification
+
+data class NotificationTokenResponse(
+    val id: Long,
+    val memberId: Long,
+    val fcmToken: String,
+    val identificationKey: String,
+)

--- a/data/src/main/java/com/depromeet/threedays/data/repository/DeviceUniqueIdRepositoryImpl.kt
+++ b/data/src/main/java/com/depromeet/threedays/data/repository/DeviceUniqueIdRepositoryImpl.kt
@@ -1,0 +1,27 @@
+package com.depromeet.threedays.data.repository
+
+import com.depromeet.threedays.data.datasource.datastore.DataStoreDataSource
+import com.depromeet.threedays.domain.repository.DeviceUniqueIdRepository
+import javax.inject.Inject
+
+class DeviceUniqueIdRepositoryImpl @Inject constructor(
+    private val dataStoreDataSource: DataStoreDataSource,
+) : DeviceUniqueIdRepository {
+    override suspend fun save(deviceUniqueId: String): String {
+        dataStoreDataSource.writeDataStore(
+            key = DEVICE_UNIQUE_ID_KEY,
+            value = deviceUniqueId,
+        )
+        return deviceUniqueId
+    }
+
+    override suspend fun findOne(): String? {
+        return dataStoreDataSource.readDataStore(
+            key = DEVICE_UNIQUE_ID_KEY,
+        )
+    }
+
+    companion object {
+        const val DEVICE_UNIQUE_ID_KEY = "THREE_DAYS:DEVICE_UNIQUE_ID"
+    }
+}

--- a/data/src/main/java/com/depromeet/threedays/data/repository/NotificationHistoryRepositoryImpl.kt
+++ b/data/src/main/java/com/depromeet/threedays/data/repository/NotificationHistoryRepositoryImpl.kt
@@ -1,6 +1,6 @@
 package com.depromeet.threedays.data.repository
 
-import com.depromeet.threedays.data.datasource.notification.NotificationHistoryRemoteDataSource
+import com.depromeet.threedays.data.datasource.notification.history.NotificationHistoryRemoteDataSource
 import com.depromeet.threedays.data.mapper.toNotificationHistory
 import com.depromeet.threedays.domain.entity.DataState
 import com.depromeet.threedays.domain.entity.notification.NotificationHistory

--- a/data/src/main/java/com/depromeet/threedays/data/repository/NotificationTokenRepositoryImpl.kt
+++ b/data/src/main/java/com/depromeet/threedays/data/repository/NotificationTokenRepositoryImpl.kt
@@ -1,0 +1,28 @@
+package com.depromeet.threedays.data.repository
+
+import com.depromeet.threedays.data.datasource.notification.token.NotificationTokenLocalDataSource
+import com.depromeet.threedays.data.datasource.notification.token.NotificationTokenRemoteDataSource
+import com.depromeet.threedays.data.entity.notification.NotificationTokenRequest
+import com.depromeet.threedays.domain.repository.NotificationTokenRepository
+import javax.inject.Inject
+
+class NotificationTokenRepositoryImpl @Inject constructor(
+    private val notificationTokenRemoteDataSource: NotificationTokenRemoteDataSource,
+    private val notificationTokenLocalDataSource: NotificationTokenLocalDataSource,
+): NotificationTokenRepository {
+    override suspend fun updateToken(
+        deviceUniqueId: String,
+        notificationToken: String
+    ) {
+        notificationTokenRemoteDataSource.updateToken(
+            notificationTokenRequest = NotificationTokenRequest(
+                fcmToken = notificationToken,
+                identificationKey = deviceUniqueId,
+            )
+        )
+    }
+
+    override suspend fun getToken(): String? {
+        return notificationTokenLocalDataSource.getToken()
+    }
+}

--- a/domain/src/main/java/com/depromeet/threedays/domain/repository/DeviceUniqueIdRepository.kt
+++ b/domain/src/main/java/com/depromeet/threedays/domain/repository/DeviceUniqueIdRepository.kt
@@ -1,0 +1,6 @@
+package com.depromeet.threedays.domain.repository
+
+interface DeviceUniqueIdRepository {
+    suspend fun save(deviceUniqueId: String): String
+    suspend fun findOne(): String?
+}

--- a/domain/src/main/java/com/depromeet/threedays/domain/repository/NotificationTokenRepository.kt
+++ b/domain/src/main/java/com/depromeet/threedays/domain/repository/NotificationTokenRepository.kt
@@ -1,0 +1,10 @@
+package com.depromeet.threedays.domain.repository
+
+interface NotificationTokenRepository {
+    suspend fun updateToken(
+        deviceUniqueId: String,
+        notificationToken: String,
+    )
+
+    suspend fun getToken(): String?
+}

--- a/domain/src/main/java/com/depromeet/threedays/domain/usecase/notification/token/UpdateNotificationTokenUseCase.kt
+++ b/domain/src/main/java/com/depromeet/threedays/domain/usecase/notification/token/UpdateNotificationTokenUseCase.kt
@@ -1,0 +1,37 @@
+package com.depromeet.threedays.domain.usecase.notification.token
+
+import com.depromeet.threedays.domain.repository.DeviceUniqueIdRepository
+import com.depromeet.threedays.domain.repository.NotificationTokenRepository
+import kotlinx.coroutines.coroutineScope
+import java.util.*
+import javax.inject.Inject
+
+class UpdateNotificationTokenUseCase @Inject constructor(
+    private val deviceUniqueIdRepository: DeviceUniqueIdRepository,
+    private val notificationTokenRepository: NotificationTokenRepository,
+) {
+    suspend operator fun invoke(notificationToken: String) {
+        if (notificationToken.isBlank()) {
+            throw IllegalArgumentException("'notificationToken' must not be null, empty or blank. notificationToken: $notificationToken")
+        }
+        val deviceUniqueId = coroutineScope {
+            getOrCreateDeviceUniqueId()
+        }
+        coroutineScope {
+            notificationTokenRepository.updateToken(
+                deviceUniqueId = deviceUniqueId,
+                notificationToken = notificationToken,
+            )
+        }
+    }
+
+    private suspend fun getOrCreateDeviceUniqueId(): String {
+        val deviceUniqueId = deviceUniqueIdRepository.findOne()
+        if (deviceUniqueId != null) {
+            return deviceUniqueId
+        }
+        return deviceUniqueIdRepository.save(
+            deviceUniqueId = UUID.randomUUID().toString(),
+        )
+    }
+}

--- a/presentation/signup/src/main/java/com/depromeet/threedays/signup/SignupActivity.kt
+++ b/presentation/signup/src/main/java/com/depromeet/threedays/signup/SignupActivity.kt
@@ -35,19 +35,20 @@ class SignupActivity: BaseActivity<ActivitySignupBinding>(R.layout.activity_sign
             lifecycleScope.launch {
                 kotlin.runCatching {
                     UserApiClient.loginWithKakaoOrThrow(context)
-                }.onSuccess { OAuthToken ->
+                }.onSuccess { oAuthToken ->
                     UserApiClient.instance.me { user, _ ->
                         if (user != null) {
                             viewModel.createMember(
-                                socialToken = OAuthToken.accessToken
+                                socialToken = oAuthToken.accessToken
                             )
+                            viewModel.updateFcmToken()
                         }
                     }
                 }.onFailure { throwable ->
                     if (throwable is ClientError && throwable.reason == ClientErrorCause.Cancelled) {
                         Timber.d("사용자가 명시적으로 카카오 로그인 취소")
                     } else {
-                        Timber.d("로그인 실패 : ${throwable.message}")
+                        Timber.d(throwable, "로그인 실패 : ${throwable.message}")
                     }
                 }
             }

--- a/presentation/signup/src/main/java/com/depromeet/threedays/signup/SignupViewModel.kt
+++ b/presentation/signup/src/main/java/com/depromeet/threedays/signup/SignupViewModel.kt
@@ -6,7 +6,9 @@ import androidx.lifecycle.distinctUntilChanged
 import androidx.lifecycle.viewModelScope
 import com.depromeet.threedays.core.BaseViewModel
 import com.depromeet.threedays.domain.entity.member.AuthenticationProvider
+import com.depromeet.threedays.domain.repository.NotificationTokenRepository
 import com.depromeet.threedays.domain.usecase.auth.CreateMemberUserCase
+import com.depromeet.threedays.domain.usecase.notification.token.UpdateNotificationTokenUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import timber.log.Timber
@@ -14,7 +16,9 @@ import javax.inject.Inject
 
 @HiltViewModel
 class SignupViewModel @Inject constructor(
-    private val createMemberUserCase: CreateMemberUserCase
+    private val createMemberUserCase: CreateMemberUserCase,
+    private val notificationTokenRepository: NotificationTokenRepository,
+    private val updateNotificationTokenUseCase: UpdateNotificationTokenUseCase,
 ) : BaseViewModel() {
 
     private val _isSuccess = MutableLiveData(false)
@@ -33,6 +37,17 @@ class SignupViewModel @Inject constructor(
             }.onFailure { throwable ->
                 Timber.e("--- SignupViewModel - Signup error: ${throwable.message}")
             }
+        }
+    }
+
+    fun updateFcmToken() {
+        viewModelScope.launch {
+            notificationTokenRepository.getToken()
+                ?.runCatching {
+                    updateNotificationTokenUseCase(notificationToken = this)
+                }?.onFailure { e ->
+                    Timber.e(e, "Failed to update registration token")
+                }
         }
     }
 }


### PR DESCRIPTION
## 💁‍♂️ 변경 내용
### AS-IS

### TO-BE
- 회원가입 성공시 firebase registration token 을 api 서버에 등록합니다. 
## 📢 전달사항
- 앱 처음 설치시 `FCMService.onNewToken(String)` 콜백이 스플래시 스크린쯤에서 실행되는데, 이때는 로그인/가입 전이라 memberId 나accessToken 이 없는 상태라서.. 콜백을 제대로 사용하고 있지 않습니다. 
- FCMService 에서 usecase 를 사용하려고 inject 하려했는데 initialized 되지 않았다고 에러 발생하네요 ㅠㅠ.. 일단은 catch 로 예외 잡아서 로그만 남기게 했습니다