### PR TITLE
DEP-346 feat: 알림 권유 바텀시트 로직 변경

### DIFF
--- a/presentation/home/src/main/java/com/depromeet/threedays/home/home/dialog/NotiRecommendBottomSheet.kt
+++ b/presentation/home/src/main/java/com/depromeet/threedays/home/home/dialog/NotiRecommendBottomSheet.kt
@@ -9,7 +9,9 @@ import com.depromeet.threedays.core.util.setOnSingleClickListener
 import com.depromeet.threedays.home.R
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 
-class NotiRecommendBottomSheet : BottomSheetDialogFragment()  {
+class NotiRecommendBottomSheet(
+    val onConfirmClick: () -> Unit
+) : BottomSheetDialogFragment()  {
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
@@ -25,6 +27,7 @@ class NotiRecommendBottomSheet : BottomSheetDialogFragment()  {
         val btnConfirm = view.findViewById<Button>(R.id.btn_confirm)
         btnConfirm.setOnSingleClickListener {
             dismiss()
+            onConfirmClick()
         }
     }
 


### PR DESCRIPTION
## 💁‍♂️ 변경 내용
### AS-IS
- StateFlow로 바텀 시트 띄워야 할 유무를 정하다 보니 바텀 시트가 중첩해서 뜨거나 백그라운드에 갔다오면 또 뜨는 버그가 있었습니다.

### TO-BE
- SharedFlow로 관리하여 한 번만 뜨도록 했습니다.

## 📢 전달사항
그 외에 첫 번째 방문하는 사용자인지 검사하는 시점을 변경했습니다.
onViewCreated에서 했더니 너무 빨라서 미처 collect를 못하길래
viewModel의 init으로 옮겼습니다.