### PR TITLE
DEP-369 짝꿍 특정 페이지 status bar 색상 다르게 주기 / 버그 수정

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,7 +9,6 @@
     <application
         android:name=".ThreeDaysApplication"
         android:allowBackup="true"
-        android:usesCleartextTraffic="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"
@@ -17,6 +16,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.ThreeDays"
+        android:usesCleartextTraffic="true"
         tools:targetApi="31">
 
         <activity
@@ -55,24 +55,27 @@
 
         <activity
             android:name="com.depromeet.threedays.onboarding.OnboardingActivity"
-            android:noHistory="true"
-            android:exported="false" />
+            android:exported="false"
+            android:noHistory="true" />
 
         <activity
             android:name="com.depromeet.threedays.mypage.archived_habit.ArchivedHabitActivity"
             android:exported="false" />
 
         <activity android:name=".mate.create.step1.ConnectHabitActivity"
+            android:exported="false"
             android:taskAffinity="com.depromeet.threedays.mate"
-            android:exported="false" />
+            android:theme="@style/WhiteStatusTheme" />
 
         <activity android:name=".mate.create.step2.ChooseMateTypeActivity"
+            android:exported="false"
             android:taskAffinity="com.depromeet.threedays.mate"
-            android:exported="false" />
+            android:theme="@style/WhiteStatusTheme" />
 
         <activity android:name=".mate.create.step3.SetMateNicknameActivity"
+            android:exported="false"
             android:taskAffinity="com.depromeet.threedays.mate"
-            android:exported="false" />
+            android:theme="@style/WhiteStatusTheme" />
 
         <activity android:name="com.depromeet.threedays.policy.PolicyActivity"
             android:exported="false" />

--- a/core-design-system/src/main/res/values/themes.xml
+++ b/core-design-system/src/main/res/values/themes.xml
@@ -38,4 +38,20 @@
     <style name="BottomNavigationView.Active" parent="@style/TextAppearance.AppCompat.Caption">
         <item name="android:textSize">11sp</item>
     </style>
+
+    <style name="WhiteStatusTheme" parent="Theme.MaterialComponents.Light.NoActionBar">
+        <!-- Primary brand color. -->
+        <item name="colorPrimary">@color/primary</item>
+        <item name="colorPrimaryVariant">@color/press</item>
+        <item name="colorOnPrimary">@color/white</item>
+        <!-- Secondary brand color. -->
+        <item name="colorSecondary">@color/blue_50</item>
+        <item name="colorSecondaryVariant">@color/blue_10</item>
+        <item name="colorOnSecondary">@color/black</item>
+        <!-- Status bar color. -->
+        <item name="android:statusBarColor">@color/white</item>
+        <!-- Customize your theme here. -->
+
+        <item name="android:windowLightStatusBar">true</item>
+    </style>
 </resources>

--- a/presentation/mate/src/main/java/com/depromeet/threedays/mate/MateFragment.kt
+++ b/presentation/mate/src/main/java/com/depromeet/threedays/mate/MateFragment.kt
@@ -3,6 +3,8 @@ package com.depromeet.threedays.mate
 import android.content.Intent
 import android.os.Bundle
 import android.view.View
+import android.view.WindowManager
+import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.viewModels
@@ -32,7 +34,6 @@ import kotlinx.coroutines.launch
 import java.time.LocalDate
 import javax.inject.Inject
 import com.depromeet.threedays.core_design_system.R as core_design
-
 
 @AndroidEntryPoint
 class MateFragment: BaseFragment<FragmentMateBinding, MateViewModel>(R.layout.fragment_mate) {
@@ -218,6 +219,14 @@ class MateFragment: BaseFragment<FragmentMateBinding, MateViewModel>(R.layout.fr
         binding.groupSpeechBubble.isVisible = hasMate
         binding.clBottomSheet.isVisible = hasMate
         binding.clTopLayout.setBackgroundResource(backgroundResColor)
+
+        val window = requireActivity().window
+        window.addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS)
+        if(hasMate) {
+            window.statusBarColor = ContextCompat.getColor(requireActivity(), core_design.color.gray_background)
+        } else {
+            window.statusBarColor = ContextCompat.getColor(context!!, core_design.color.white)
+        }
     }
 
     private fun setMateInfo(mateUI: MateUI?) {
@@ -317,5 +326,13 @@ class MateFragment: BaseFragment<FragmentMateBinding, MateViewModel>(R.layout.fr
                 )
             )
         }
+    }
+
+    override fun onStop() {
+        super.onStop()
+
+        val window = requireActivity().window
+        window.addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS)
+        window.statusBarColor = ContextCompat.getColor(requireActivity(), core_design.color.gray_background)
     }
 }

--- a/presentation/mate/src/main/java/com/depromeet/threedays/mate/create/step1/ConnectHabitActivity.kt
+++ b/presentation/mate/src/main/java/com/depromeet/threedays/mate/create/step1/ConnectHabitActivity.kt
@@ -81,6 +81,18 @@ class ConnectHabitActivity : BaseActivity<ActivityConnectHabitBinding>(R.layout.
         }
     }
 
+    private fun setButtonView(
+        buttonClickable: Boolean,
+        buttonBackgroundRes: Int,
+        buttonTextColor: Int
+    ) {
+        binding.btnNext.apply {
+            isClickable = buttonClickable
+            setBackgroundResource(buttonBackgroundRes)
+            setTextColor(getColor(buttonTextColor))
+        }
+    }
+
     private fun setObserve() {
         lifecycleScope.launch {
             lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
@@ -92,6 +104,11 @@ class ConnectHabitActivity : BaseActivity<ActivityConnectHabitBinding>(R.layout.
                 launch {
                     viewModel.uiState.collect {
                         binding.ivIllustrator.setBackgroundResource(it.boxImageResId)
+                        setButtonView(
+                            buttonClickable = it.buttonClickable,
+                            buttonBackgroundRes = it.buttonBackgroundRes,
+                            buttonTextColor = it.buttonTextColor,
+                        )
                     }
                 }
             }

--- a/presentation/mate/src/main/java/com/depromeet/threedays/mate/create/step1/ConnectHabitViewModel.kt
+++ b/presentation/mate/src/main/java/com/depromeet/threedays/mate/create/step1/ConnectHabitViewModel.kt
@@ -61,7 +61,10 @@ class ConnectHabitViewModel @Inject constructor(
                     Color.PINK -> R.drawable.bg_box_mate_default_pink
                     Color.BLUE -> R.drawable.bg_box_mate_default_blue
                     Color.GREEN -> R.drawable.bg_box_mate_default_green
-                }
+                },
+                buttonClickable = true,
+                buttonBackgroundRes = com.depromeet.threedays.core_design_system.R.drawable.bg_rect_gray800_r15,
+                buttonTextColor = com.depromeet.threedays.core_design_system.R.color.white
             )
         }
     }
@@ -70,4 +73,7 @@ class ConnectHabitViewModel @Inject constructor(
 data class UiState(
     val clickedHabit: HabitUI? = null,
     val boxImageResId: Int = R.drawable.bg_box_mate_default,
+    val buttonClickable: Boolean = false,
+    val buttonBackgroundRes: Int = com.depromeet.threedays.core_design_system.R.drawable.bg_rect_gray200_r15,
+    val buttonTextColor: Int = com.depromeet.threedays.core_design_system.R.color.gray_450,
 )

--- a/presentation/mate/src/main/java/com/depromeet/threedays/mate/create/step3/SetMateNicknameActivity.kt
+++ b/presentation/mate/src/main/java/com/depromeet/threedays/mate/create/step3/SetMateNicknameActivity.kt
@@ -80,6 +80,7 @@ class SetMateNicknameActivity : BaseActivity<ActivitySetMateNicknameBinding>(R.l
                 viewModel.uiState.collect {
                     setGuideTextVisible(isGuideVisible = it.isGuideVisible)
                     setButtonView(
+                        buttonClickable = it.buttonClickable,
                         buttonBackgroundRes = it.buttonBackgroundRes,
                         buttonTextColor = it.buttonTextColor,
                     )
@@ -94,9 +95,16 @@ class SetMateNicknameActivity : BaseActivity<ActivitySetMateNicknameBinding>(R.l
         binding.tvGuide.isVisible = isGuideVisible
     }
 
-    private fun setButtonView(buttonBackgroundRes: Int, buttonTextColor: Int) {
-        binding.btnNext.setBackgroundResource(buttonBackgroundRes)
-        binding.btnNext.setTextColor(getColor(buttonTextColor))
+    private fun setButtonView(
+        buttonClickable: Boolean,
+        buttonBackgroundRes: Int,
+        buttonTextColor: Int
+    ) {
+        binding.btnNext.apply {
+            isClickable = buttonClickable
+            setBackgroundResource(buttonBackgroundRes)
+            setTextColor(getColor(buttonTextColor))
+        }
     }
 
     private fun setAvailableInputLength(inputTextLength: String) {

--- a/presentation/mate/src/main/java/com/depromeet/threedays/mate/create/step3/SetMateNicknameViewModel.kt
+++ b/presentation/mate/src/main/java/com/depromeet/threedays/mate/create/step3/SetMateNicknameViewModel.kt
@@ -34,6 +34,7 @@ class SetMateNicknameViewMoodel @Inject constructor(
                 it.copy(
                     inputText = inputText,
                     inputTextLength = inputText.length.toString(),
+                    buttonClickable = inputText.isNotEmpty(),
                     buttonBackgroundRes = if(inputText.isEmpty()) {
                         core_design.drawable.bg_rect_gray200_r15
                     } else {
@@ -111,6 +112,7 @@ class SetMateNicknameViewMoodel @Inject constructor(
 data class UiState(
     val inputText: String = "",
     val inputTextLength: String = "0",
+    val buttonClickable: Boolean = false,
     val buttonBackgroundRes: Int = core_design.drawable.bg_rect_gray200_r15,
     val buttonTextColor: Int = core_design.color.gray_450,
     val isGuideVisible: Boolean = false,

--- a/presentation/mate/src/main/res/layout/fragment_mate.xml
+++ b/presentation/mate/src/main/res/layout/fragment_mate.xml
@@ -105,7 +105,6 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="24dp"
-                android:lineSpacingExtra="@dimen/Typography.Paragraph3.LineSpacingExtra"
                 android:text="@string/create_mate_guide"
                 android:textAppearance="@style/Typography.Paragraph3"
                 android:textColor="@color/gray_500"
@@ -172,7 +171,6 @@
                     android:layout_height="wrap_content"
                     android:layout_marginTop="12dp"
                     android:elevation="8dp"
-                    android:lineSpacingExtra="@dimen/Typography.Paragraph3.LineSpacingExtra"
                     android:minLines="3"
                     android:text="@string/clap_guide_content"
                     android:textAppearance="@style/Typography.Paragraph3"
@@ -378,6 +376,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginHorizontal="34dp"
                 android:layout_marginTop="36dp"
+                android:overScrollMode="never"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/tv_next_level_guide" />

--- a/presentation/mate/src/main/res/layout/fragment_mate.xml
+++ b/presentation/mate/src/main/res/layout/fragment_mate.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <data>
 
@@ -94,8 +94,8 @@
                 android:id="@+id/iv_no_mate_illustration"
                 android:layout_width="180dp"
                 android:layout_height="180dp"
-                android:src="@drawable/bg_help_mate_image"
                 android:gravity="center"
+                android:src="@drawable/bg_help_mate_image"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="@+id/gl_top_of_30_percent" />
@@ -105,6 +105,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="24dp"
+                android:lineSpacingExtra="@dimen/Typography.Paragraph3.LineSpacingExtra"
                 android:text="@string/create_mate_guide"
                 android:textAppearance="@style/Typography.Paragraph3"
                 android:textColor="@color/gray_500"
@@ -121,10 +122,10 @@
                 android:gravity="center"
                 android:paddingHorizontal="44dp"
                 android:paddingVertical="14dp"
+                android:stateListAnimator="@null"
                 android:text="@string/create_mate"
                 android:textAppearance="@style/Typography.Button1"
                 android:textColor="@color/white"
-                android:stateListAnimator="@null"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/tv_create_mate_guide" />
@@ -171,6 +172,7 @@
                     android:layout_height="wrap_content"
                     android:layout_marginTop="12dp"
                     android:elevation="8dp"
+                    android:lineSpacingExtra="@dimen/Typography.Paragraph3.LineSpacingExtra"
                     android:minLines="3"
                     android:text="@string/clap_guide_content"
                     android:textAppearance="@style/Typography.Paragraph3"
@@ -206,9 +208,9 @@
                 android:text="@string/achieve_max_level"
                 android:textAppearance="@style/Typography.Display2"
                 android:textColor="@color/gray_600"
-                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintBottom_toTopOf="@+id/btn_save_mate"
                 app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintBottom_toTopOf="@+id/btn_save_mate" />
+                app:layout_constraintStart_toStartOf="parent" />
 
             <androidx.appcompat.widget.AppCompatButton
                 android:id="@+id/btn_save_mate"
@@ -219,13 +221,13 @@
                 android:gravity="center"
                 android:paddingHorizontal="32dp"
                 android:paddingVertical="12dp"
+                android:stateListAnimator="@null"
                 android:text="@string/save_mate"
                 android:textAppearance="@style/Typography.Button3"
                 android:textColor="@color/white"
-                android:stateListAnimator="@null"
+                app:layout_constraintBottom_toTopOf="@+id/iv_illustration"
                 app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintBottom_toTopOf="@+id/iv_illustration"/>
+                app:layout_constraintStart_toStartOf="parent"/>
 
             <TextView
                 android:id="@+id/tv_speech_bubble"
@@ -264,11 +266,11 @@
                 android:id="@+id/iv_illustration"
                 android:layout_width="180dp"
                 android:layout_height="180dp"
-                tools:background="@drawable/bg_mate_level_1"
                 app:layout_constraintBottom_toTopOf="@+id/gl_mock_bottom_sheet"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/gl_bottom_of_toolbar" />
+                app:layout_constraintTop_toBottomOf="@+id/gl_bottom_of_toolbar"
+                tools:background="@drawable/bg_mate_level_1" />
 
             <TextView
                 android:id="@+id/tv_level"
@@ -374,18 +376,17 @@
                 android:id="@+id/rv_clap"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:overScrollMode="never"
-                android:layout_marginTop="36dp"
                 android:layout_marginHorizontal="34dp"
-                app:layout_constraintTop_toBottomOf="@+id/tv_next_level_guide"
+                android:layout_marginTop="36dp"
+                app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintEnd_toEndOf="parent" />
+                app:layout_constraintTop_toBottomOf="@+id/tv_next_level_guide" />
 
             <LinearLayout
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginBottom="13dp"
                 android:layout_marginEnd="20dp"
+                android:layout_marginBottom="13dp"
                 app:layout_constraintBottom_toBottomOf="@+id/rv_clap"
                 app:layout_constraintEnd_toEndOf="@id/rv_clap">
 


### PR DESCRIPTION
## 💁‍♂️ 변경 내용
### AS-IS
- stastus bar 색상이 항상 gray 색이였습니다. gray 색이야!
- 짝꿍 만들기 과정에서 아무것도 선택하지 않고 버튼을 누르면 앱이 죽는 버그가 있었습니다. (아무도 발견 못했길래 잠수함 패치 꼬로록...)

### TO-BE
- 특정 페이지의 status bar 색상을 흰색으로 해달라고 하셔서 변경했습니다.
- 아무것도 선택하지 않으면 버튼이 선택되지 않게 했습니다.

## 📢 전달사항
plugin을 설치했더니 코드 재정렬 같은 것도 같이 들어가서 변경점이 많아보이지만
헷갈릴정도는 아닌 것 같아서 냅뒀습니다.