### PR TITLE
DEP-377 bugfix: 화살표 방향 변경, bottom sheet 뒷배경 적용, 터치 범위 재조정

### DIFF
--- a/presentation/mate/src/main/java/com/depromeet/threedays/mate/MateFragment.kt
+++ b/presentation/mate/src/main/java/com/depromeet/threedays/mate/MateFragment.kt
@@ -4,6 +4,7 @@ import android.content.Intent
 import android.os.Bundle
 import android.view.View
 import android.view.WindowManager
+import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
 import androidx.fragment.app.DialogFragment
@@ -15,6 +16,8 @@ import androidx.recyclerview.widget.GridLayoutManager
 import com.depromeet.threedays.core.BaseFragment
 import com.depromeet.threedays.core.analytics.*
 import com.depromeet.threedays.core.extensions.Empty
+import com.depromeet.threedays.core.extensions.gone
+import com.depromeet.threedays.core.extensions.visible
 import com.depromeet.threedays.core.util.*
 import com.depromeet.threedays.domain.entity.Color
 import com.depromeet.threedays.domain.entity.habit.SingleHabit
@@ -39,6 +42,7 @@ import com.depromeet.threedays.core_design_system.R as core_design
 class MateFragment: BaseFragment<FragmentMateBinding, MateViewModel>(R.layout.fragment_mate) {
     override val viewModel by viewModels<MateViewModel>()
     lateinit var clapAdapter: ClapAdapter
+    lateinit var behavior: BottomSheetBehavior<ConstraintLayout>
 
     @Inject
     lateinit var connectHabitNavigator: ConnectHabitNavigator
@@ -151,7 +155,7 @@ class MateFragment: BaseFragment<FragmentMateBinding, MateViewModel>(R.layout.fr
                 )
             ).show(parentFragmentManager, ThreeDaysDialogFragment.TAG)
         }
-        val behavior = BottomSheetBehavior.from(binding.clBottomSheet)
+        behavior = BottomSheetBehavior.from(binding.clBottomSheet)
         behavior.addBottomSheetCallback(object : BottomSheetBehavior.BottomSheetCallback() {
             override fun onSlide(bottomSheet: View, slideOffset: Float) {
 
@@ -159,10 +163,13 @@ class MateFragment: BaseFragment<FragmentMateBinding, MateViewModel>(R.layout.fr
             override fun onStateChanged(bottomSheet: View, newState: Int) {
                 when(newState) {
                     BottomSheetBehavior.STATE_COLLAPSED-> {
-
+                        binding.ivArrow.setImageResource(core_design.drawable.ic_arrow_up)
+                        binding.viewBg.gone()
                     }
                     BottomSheetBehavior.STATE_DRAGGING-> {
-
+                        if(!binding.viewBg.isVisible) {
+                            binding.viewBg.visible()
+                        }
                     }
                     BottomSheetBehavior.STATE_EXPANDED-> {
                         AnalyticsUtil.event(
@@ -172,6 +179,7 @@ class MateFragment: BaseFragment<FragmentMateBinding, MateViewModel>(R.layout.fr
                                 MixPanelEvent.ButtonType to ButtonType.MateClapOpen,
                             )
                         )
+                        binding.ivArrow.setImageResource(core_design.drawable.ic_arrow_down)
                     }
                     BottomSheetBehavior.STATE_HIDDEN-> {
 
@@ -182,6 +190,15 @@ class MateFragment: BaseFragment<FragmentMateBinding, MateViewModel>(R.layout.fr
                 }
             }
         })
+        binding.ivArrow.setOnSingleClickListener {
+            if(behavior.state == BottomSheetBehavior.STATE_COLLAPSED) {
+                binding.viewBg.visible()
+                behavior.state = BottomSheetBehavior.STATE_EXPANDED
+            } else if(behavior.state == BottomSheetBehavior.STATE_EXPANDED) {
+                binding.viewBg.gone()
+                behavior.state = BottomSheetBehavior.STATE_COLLAPSED
+            }
+        }
     }
 
     private fun setObserve() {

--- a/presentation/mate/src/main/res/layout/fragment_mate.xml
+++ b/presentation/mate/src/main/res/layout/fragment_mate.xml
@@ -309,6 +309,17 @@
                 app:layout_constraintEnd_toEndOf="@id/gl_end"
                 app:layout_constraintStart_toStartOf="@id/gl_begin"
                 app:layout_constraintTop_toBottomOf="@+id/tv_mate_nickname" />
+
+            <View
+                android:id="@+id/view_bg"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:background="#99121313"
+                android:visibility="gone"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"/>
         </androidx.constraintlayout.widget.ConstraintLayout>
 
         <!-- Persistent Bottom Sheet -->
@@ -323,10 +334,10 @@
             app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior">
 
             <ImageView
-                android:id="@+id/iv_arrow_up"
-                android:layout_width="24dp"
-                android:layout_height="24dp"
-                android:layout_marginTop="12dp"
+                android:id="@+id/iv_arrow"
+                android:layout_width="48dp"
+                android:layout_height="48dp"
+                android:padding="12dp"
                 android:src="@drawable/ic_arrow_up"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
@@ -349,14 +360,13 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="8dp"
-                android:layout_marginTop="10dp"
                 android:text="@string/habit_sample_title"
                 android:textAppearance="@style/Typography.Body1"
                 android:textColor="@color/gray_800"
                 app:layout_constraintBottom_toBottomOf="@+id/tv_habit_emoji"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toEndOf="@+id/tv_habit_emoji"
-                app:layout_constraintTop_toBottomOf="@id/iv_arrow_up" />
+                app:layout_constraintTop_toBottomOf="@id/iv_arrow" />
 
             <TextView
                 android:id="@+id/tv_next_level_guide"


### PR DESCRIPTION
## 💁‍♂️ 변경 내용
### AS-IS
- 짝꿍 페이지에서 바텀 시트를 올리든 내리든 항상 화살표 방향이 같았습니다.
- bottom sheet를 펼쳐도 뒷배경에 변화가 없었습니다
- 화살표를 클릭해도 액션이 없었습니다.
- 화살표의 터치 범위가 좁았습니다.

### TO-BE
- 바텀시트 상태에 따라 화살표 방향이 변경됩니다.
- 바텀시트를 펼치면 뒷배경이 불투명하게 처리됩니다.
- 화살표를 클릭하면 바텀시트가 올라가고 내려갑니다.
- 화살표의 터치범위를 넓혀 뒤에 있는 짝꿍이 클릭되지 않도록 했습니다.

## 📢 전달사항
