### PR TITLE
DEP-379 bugfix: 세번째 박수 클릭 시 생기는 버그들 수정

### DIFF
--- a/core/src/main/java/com/depromeet/threedays/core/util/ThreeDaysImageSnackBar.kt
+++ b/core/src/main/java/com/depromeet/threedays/core/util/ThreeDaysImageSnackBar.kt
@@ -11,6 +11,7 @@ import com.google.android.material.snackbar.Snackbar
 class ThreeDaysImageSnackBar {
     fun show(
         view: View,
+        imageResId: Int,
         title: String,
         content: String,
         actionText: String,
@@ -30,6 +31,7 @@ class ThreeDaysImageSnackBar {
             params.gravity = Gravity.TOP
         }
 
+        binding.ivIllustrator.setImageResource(imageResId)
         binding.tvTitle.text = title
         binding.tvContent.text = content
         binding.tvActionButton.text = actionText

--- a/data/src/main/java/com/depromeet/threedays/data/di/RepositoryModule.kt
+++ b/data/src/main/java/com/depromeet/threedays/data/di/RepositoryModule.kt
@@ -25,6 +25,12 @@ abstract class RepositoryModule {
 
     @Binds
     @Singleton
+    abstract fun bindsTodayFirstVisitRepository(
+        repository: TodayFirstVisitRepositoryImpl,
+    ): TodayFirstVisitRepository
+
+    @Binds
+    @Singleton
     abstract fun bindsMaxLevelMateRepository(
         repository: MaxLevelMateRepositoryImpl,
     ): MaxLevelMateRepository

--- a/data/src/main/java/com/depromeet/threedays/data/entity/RewardHistoryEntity.kt
+++ b/data/src/main/java/com/depromeet/threedays/data/entity/RewardHistoryEntity.kt
@@ -3,5 +3,5 @@ package com.depromeet.threedays.data.entity
 import java.time.LocalDateTime
 
 data class RewardHistoryEntity(
-    val createAt: LocalDateTime,
+    val createAt: LocalDateTime?,
 )

--- a/data/src/main/java/com/depromeet/threedays/data/repository/TodayFirstVisitRepositoryImpl.kt
+++ b/data/src/main/java/com/depromeet/threedays/data/repository/TodayFirstVisitRepositoryImpl.kt
@@ -1,0 +1,16 @@
+package com.depromeet.threedays.data.repository
+
+import com.depromeet.threedays.data.datasource.datastore.DataStoreDataSource
+import com.depromeet.threedays.domain.repository.TodayFirstVisitRepository
+import javax.inject.Inject
+
+class TodayFirstVisitRepositoryImpl @Inject constructor(
+    private val dataStoreDataSource: DataStoreDataSource,
+) : TodayFirstVisitRepository {
+
+    override suspend fun readTodayFirstVisit(key: String): String? =
+        dataStoreDataSource.readDataStore(key)
+
+    override suspend fun writeTodayFirstVisit(key: String, value: String) =
+        dataStoreDataSource.writeDataStore(key = key, value = value)
+}

--- a/domain/src/main/java/com/depromeet/threedays/domain/entity/mate/Mate.kt
+++ b/domain/src/main/java/com/depromeet/threedays/domain/entity/mate/Mate.kt
@@ -7,7 +7,7 @@ data class Mate(
     val habitId: Long,
     val memberId: Long,
     val title: String,
-    val createAt: LocalDateTime,
+    val createAt: LocalDateTime?, // TODO: null로 들어와서 임시 조치
     val level: Int,
     val reward: Int,
     val rewardHistory: List<RewardHistory>?,
@@ -18,6 +18,6 @@ data class Mate(
     val status: String,
 ) {
     data class RewardHistory(
-        val createAt: LocalDateTime,
+        val createAt: LocalDateTime?,
     )
 }

--- a/domain/src/main/java/com/depromeet/threedays/domain/repository/TodayFirstVisitRepository.kt
+++ b/domain/src/main/java/com/depromeet/threedays/domain/repository/TodayFirstVisitRepository.kt
@@ -1,0 +1,6 @@
+package com.depromeet.threedays.domain.repository
+
+interface TodayFirstVisitRepository {
+    suspend fun readTodayFirstVisit(key: String): String?
+    suspend fun writeTodayFirstVisit(key: String, value: String)
+}

--- a/domain/src/main/java/com/depromeet/threedays/domain/usecase/today_visit/ReadTodayFirstVisitUseCase.kt
+++ b/domain/src/main/java/com/depromeet/threedays/domain/usecase/today_visit/ReadTodayFirstVisitUseCase.kt
@@ -1,0 +1,14 @@
+package com.depromeet.threedays.domain.usecase.today_visit
+
+import com.depromeet.threedays.domain.repository.TodayFirstVisitRepository
+import javax.inject.Inject
+
+class ReadTodayFirstVisitUseCase @Inject constructor(val repository: TodayFirstVisitRepository) {
+    suspend fun execute(): String? {
+        return repository.readTodayFirstVisit(TODAY_FIRST_VISIT)
+    }
+
+    companion object {
+        const val TODAY_FIRST_VISIT = "TODAY_FIRST_VISIT"
+    }
+}

--- a/domain/src/main/java/com/depromeet/threedays/domain/usecase/today_visit/WriteTodayFirstVisitUseCase.kt
+++ b/domain/src/main/java/com/depromeet/threedays/domain/usecase/today_visit/WriteTodayFirstVisitUseCase.kt
@@ -1,0 +1,11 @@
+package com.depromeet.threedays.domain.usecase.today_visit
+
+import com.depromeet.threedays.domain.repository.TodayFirstVisitRepository
+import com.depromeet.threedays.domain.usecase.today_visit.ReadTodayFirstVisitUseCase.Companion.TODAY_FIRST_VISIT
+import javax.inject.Inject
+
+class WriteTodayFirstVisitUseCase @Inject constructor(val repository: TodayFirstVisitRepository) {
+    suspend fun execute(today: String) {
+        return repository.writeTodayFirstVisit(key = TODAY_FIRST_VISIT, value = today)
+    }
+}

--- a/presentation/home/src/main/java/com/depromeet/threedays/home/MainActivity.kt
+++ b/presentation/home/src/main/java/com/depromeet/threedays/home/MainActivity.kt
@@ -1,10 +1,10 @@
 package com.depromeet.threedays.home
 
-import android.animation.Animator
 import android.os.Bundle
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import com.depromeet.threedays.core.BaseActivity
+import com.depromeet.threedays.core.util.setOnSingleClickListener
 import com.depromeet.threedays.history.HistoryFragment
 import com.depromeet.threedays.home.databinding.ActivityMainBinding
 import com.depromeet.threedays.home.home.HomeFragment
@@ -49,26 +49,14 @@ class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main) {
     }
 
     private fun initEvent() {
-        binding.lottieClap.addAnimatorListener(object : Animator.AnimatorListener {
-            override fun onAnimationStart(p0: Animator) {
-                binding.congratulationAnimationGroup.isVisible = true
-            }
-
-            override fun onAnimationEnd(p0: Animator) {
-                binding.congratulationAnimationGroup.isVisible = false
-            }
-
-            override fun onAnimationCancel(p0: Animator) {
-
-            }
-
-            override fun onAnimationRepeat(p0: Animator) {
-
-            }
-        })
+        binding.ivClose.setOnSingleClickListener {
+            binding.congratulationAnimationGroup.isVisible = false
+            binding.lottieClap.cancelAnimation()
+        }
     }
 
     fun startCongratulateThirdClapAnimation() {
+        binding.congratulationAnimationGroup.isVisible = true
         binding.lottieClap.playAnimation()
     }
 }

--- a/presentation/home/src/main/java/com/depromeet/threedays/home/MainActivity.kt
+++ b/presentation/home/src/main/java/com/depromeet/threedays/home/MainActivity.kt
@@ -14,6 +14,8 @@ import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main) {
+    lateinit var onCloseClick: () -> Unit
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
@@ -44,19 +46,26 @@ class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main) {
         }
     }
 
-    private fun changeFragment(fragment: Fragment) {
-        supportFragmentManager.beginTransaction().replace(binding.flMain.id, fragment).commit()
-    }
-
     private fun initEvent() {
         binding.ivClose.setOnSingleClickListener {
-            binding.congratulationAnimationGroup.isVisible = false
-            binding.lottieClap.cancelAnimation()
+            stopCongratulateThirdClapAnimation()
+            onCloseClick()
+
         }
     }
 
-    fun startCongratulateThirdClapAnimation() {
+    fun changeFragment(fragment: Fragment) {
+        supportFragmentManager.beginTransaction().replace(binding.flMain.id, fragment).commit()
+    }
+
+    fun startCongratulateThirdClapAnimation(onCloseClick: () -> Unit) {
         binding.congratulationAnimationGroup.isVisible = true
         binding.lottieClap.playAnimation()
+        this.onCloseClick = onCloseClick
+    }
+
+    fun stopCongratulateThirdClapAnimation() {
+        binding.congratulationAnimationGroup.isVisible = false
+        binding.lottieClap.cancelAnimation()
     }
 }

--- a/presentation/home/src/main/java/com/depromeet/threedays/home/home/HabitAdapter.kt
+++ b/presentation/home/src/main/java/com/depromeet/threedays/home/home/HabitAdapter.kt
@@ -8,7 +8,7 @@ import com.depromeet.threedays.home.home.model.HabitUI
 import kotlin.reflect.KFunction0
 
 class HabitAdapter(
-    private val createHabitAchievement: (Long) -> Unit,
+    private val createHabitAchievement: (HabitUI) -> Unit,
     private val deleteHabitAchievement: (Long, Long) -> Unit,
     private val onCreateHabitClick: KFunction0<Unit>,
     private val onMoreClick: (HabitUI) -> Unit,

--- a/presentation/home/src/main/java/com/depromeet/threedays/home/home/HabitAdapter.kt
+++ b/presentation/home/src/main/java/com/depromeet/threedays/home/home/HabitAdapter.kt
@@ -8,7 +8,7 @@ import com.depromeet.threedays.home.home.model.HabitUI
 import kotlin.reflect.KFunction0
 
 class HabitAdapter(
-    private val createHabitAchievement: (Long, Boolean) -> Unit,
+    private val createHabitAchievement: (Long) -> Unit,
     private val deleteHabitAchievement: (Long, Long) -> Unit,
     private val onCreateHabitClick: KFunction0<Unit>,
     private val onMoreClick: (HabitUI) -> Unit,

--- a/presentation/home/src/main/java/com/depromeet/threedays/home/home/HabitViewHolder.kt
+++ b/presentation/home/src/main/java/com/depromeet/threedays/home/home/HabitViewHolder.kt
@@ -17,7 +17,7 @@ class HabitViewHolder(private val view: ItemHabitBinding) : RecyclerView.ViewHol
     fun onBind(
         habitUI: HabitUI,
         context: Context,
-        createHabitAchievement: (Long, Boolean) -> Unit,
+        createHabitAchievement: (Long) -> Unit,
         deleteHabitAchievement: (Long, Long) -> Unit,
         onMoreClick: (HabitUI) -> Unit
     ) {
@@ -129,7 +129,7 @@ class HabitViewHolder(private val view: ItemHabitBinding) : RecyclerView.ViewHol
 
     private fun initEvent(
         habitUI: HabitUI,
-        createHabitAchievement: (Long, Boolean) -> Unit,
+        createHabitAchievement: (Long) -> Unit,
         deleteHabitAchievement: (Long, Long) -> Unit,
         onMoreClick: (HabitUI) -> Unit
     ) {
@@ -164,7 +164,7 @@ class HabitViewHolder(private val view: ItemHabitBinding) : RecyclerView.ViewHol
     private fun switchHabitState(
         clickedIndex: Int,
         habitUI: HabitUI,
-        createHabitAchievement: (Long, Boolean) -> Unit,
+        createHabitAchievement: (Long) -> Unit,
         deleteHabitAchievement: (Long, Long) -> Unit,
     ) {
         val isDeleteAchievementAvailable = habitUI.isTodayChecked && (clickedIndex == habitUI.todayIndex - 1)
@@ -181,7 +181,7 @@ class HabitViewHolder(private val view: ItemHabitBinding) : RecyclerView.ViewHol
                 textColor = habitUI.checkableTextColor
             )
         } else if(isCreateAchievementAvailable) {
-            createHabitAchievement(habitUI.habitId, clickedIndex == LAST_CLAP_INDEX)
+            createHabitAchievement(habitUI.habitId)
             setCheckedButton(
                 targetIndex = clickedIndex,
                 resId = habitUI.checkedBackgroundResId
@@ -200,7 +200,5 @@ class HabitViewHolder(private val view: ItemHabitBinding) : RecyclerView.ViewHol
                 )
             )
         }
-
-        const val LAST_CLAP_INDEX = 2
     }
 }

--- a/presentation/home/src/main/java/com/depromeet/threedays/home/home/HabitViewHolder.kt
+++ b/presentation/home/src/main/java/com/depromeet/threedays/home/home/HabitViewHolder.kt
@@ -31,32 +31,41 @@ class HabitViewHolder(private val view: ItemHabitBinding) : RecyclerView.ViewHol
         habitUI.run {
             view.tvHabitDayOfWeek.text = convertDayListToString(dayOfWeeks)
 
-            for (targetIndex in 0..2) {
-                if (targetIndex < todayIndex) {
+            if(todayIndex == 0 && todayHabitAchievementId != null) {
+                for (i in 0..2) {
                     setCheckedButton(
-                        targetIndex = targetIndex,
+                        targetIndex = i,
                         resId = checkedBackgroundResId
                     )
-                } else if (targetIndex == todayIndex) {
-                    if(isTodayChecked) {
+                }
+            } else {
+                for (targetIndex in 0..2) {
+                    if (targetIndex < todayIndex) {
+                        setCheckedButton(
+                            targetIndex = targetIndex,
+                            resId = checkedBackgroundResId
+                        )
+                    } else if (targetIndex == todayIndex) {
+                        if(isTodayChecked) {
+                            setUncheckedButton(
+                                targetIndex = targetIndex,
+                                resId = R.drawable.bg_oval_gray,
+                                textColor = R.color.gray_400
+                            )
+                        } else {
+                            setUncheckedButton(
+                                targetIndex = targetIndex,
+                                resId = checkableBackgroundResId,
+                                textColor = checkableTextColor
+                            )
+                        }
+                    } else {
                         setUncheckedButton(
                             targetIndex = targetIndex,
                             resId = R.drawable.bg_oval_gray,
                             textColor = R.color.gray_400
                         )
-                    } else {
-                        setUncheckedButton(
-                            targetIndex = targetIndex,
-                            resId = checkableBackgroundResId,
-                            textColor = checkableTextColor
-                        )
                     }
-                } else {
-                    setUncheckedButton(
-                        targetIndex = targetIndex,
-                        resId = R.drawable.bg_oval_gray,
-                        textColor = R.color.gray_400
-                    )
                 }
             }
         }
@@ -167,7 +176,9 @@ class HabitViewHolder(private val view: ItemHabitBinding) : RecyclerView.ViewHol
         createHabitAchievement: (Long) -> Unit,
         deleteHabitAchievement: (Long, Long) -> Unit,
     ) {
-        val isDeleteAchievementAvailable = habitUI.isTodayChecked && (clickedIndex == habitUI.todayIndex - 1)
+        val isDeleteAchievementAvailable =
+            (habitUI.isTodayChecked && (clickedIndex == habitUI.todayIndex - 1))
+                    || (habitUI.isTodayChecked && habitUI.todayIndex == 0)
         val isCreateAchievementAvailable = habitUI.isTodayChecked.not() && (clickedIndex == habitUI.todayIndex)
 
         if (isDeleteAchievementAvailable) {

--- a/presentation/home/src/main/java/com/depromeet/threedays/home/home/HabitViewHolder.kt
+++ b/presentation/home/src/main/java/com/depromeet/threedays/home/home/HabitViewHolder.kt
@@ -17,7 +17,7 @@ class HabitViewHolder(private val view: ItemHabitBinding) : RecyclerView.ViewHol
     fun onBind(
         habitUI: HabitUI,
         context: Context,
-        createHabitAchievement: (Long) -> Unit,
+        createHabitAchievement: (HabitUI) -> Unit,
         deleteHabitAchievement: (Long, Long) -> Unit,
         onMoreClick: (HabitUI) -> Unit
     ) {
@@ -138,7 +138,7 @@ class HabitViewHolder(private val view: ItemHabitBinding) : RecyclerView.ViewHol
 
     private fun initEvent(
         habitUI: HabitUI,
-        createHabitAchievement: (Long) -> Unit,
+        createHabitAchievement: (HabitUI) -> Unit,
         deleteHabitAchievement: (Long, Long) -> Unit,
         onMoreClick: (HabitUI) -> Unit
     ) {
@@ -173,7 +173,7 @@ class HabitViewHolder(private val view: ItemHabitBinding) : RecyclerView.ViewHol
     private fun switchHabitState(
         clickedIndex: Int,
         habitUI: HabitUI,
-        createHabitAchievement: (Long) -> Unit,
+        createHabitAchievement: (HabitUI) -> Unit,
         deleteHabitAchievement: (Long, Long) -> Unit,
     ) {
         val isDeleteAchievementAvailable =
@@ -192,7 +192,7 @@ class HabitViewHolder(private val view: ItemHabitBinding) : RecyclerView.ViewHol
                 textColor = habitUI.checkableTextColor
             )
         } else if(isCreateAchievementAvailable) {
-            createHabitAchievement(habitUI.habitId)
+            createHabitAchievement(habitUI)
             setCheckedButton(
                 targetIndex = clickedIndex,
                 resId = habitUI.checkedBackgroundResId

--- a/presentation/home/src/main/java/com/depromeet/threedays/home/home/HomeFragment.kt
+++ b/presentation/home/src/main/java/com/depromeet/threedays/home/home/HomeFragment.kt
@@ -29,10 +29,8 @@ import com.depromeet.threedays.home.databinding.FragmentHomeBinding
 import com.depromeet.threedays.home.home.dialog.MoreActionModal
 import com.depromeet.threedays.home.home.dialog.NotiGuideBottomSheet
 import com.depromeet.threedays.home.home.dialog.NotiRecommendBottomSheet
-import com.depromeet.threedays.navigator.ArchivedHabitNavigator
-import com.depromeet.threedays.navigator.HabitCreateNavigator
-import com.depromeet.threedays.navigator.HabitUpdateNavigator
-import com.depromeet.threedays.navigator.NotificationNavigator
+import com.depromeet.threedays.mate.MateFragment
+import com.depromeet.threedays.navigator.*
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 import java.time.ZoneId
@@ -204,6 +202,24 @@ class HomeFragment : BaseFragment<FragmentHomeBinding, HomeViewModel>(R.layout.f
         )
     }
 
+    private fun showImageSnackBar(
+        view: View,
+        imageResId: Int,
+        titleResId: Int,
+        contentResId: Int,
+        mateLevel: Int,
+        onAction: () -> Unit
+    ) {
+        ThreeDaysImageSnackBar().show(
+            view = view,
+            imageResId = imageResId,
+            title = getString(titleResId),
+            content = getString(contentResId, mateLevel),
+            actionText = getString(R.string.move),
+            onAction = onAction
+        )
+    }
+
     private fun moveToSettingForTurnOnPermission() {
         val intent = Intent(Settings.ACTION_APP_NOTIFICATION_SETTINGS)
         intent.putExtra(Settings.EXTRA_APP_PACKAGE, requireActivity().packageName)
@@ -288,7 +304,19 @@ class HomeFragment : BaseFragment<FragmentHomeBinding, HomeViewModel>(R.layout.f
                                     )
                                 }
                             )
-                            UiEffect.ShowClapAnimation -> (requireActivity() as MainActivity).startCongratulateThirdClapAnimation()
+                            is UiEffect.ShowImageSnackBar -> showImageSnackBar(
+                                view = binding.clTopLayout,
+                                imageResId = it.imageResId,
+                                titleResId = it.titleResId,
+                                contentResId = it.contentResId,
+                                mateLevel = it.mateLevel,
+                                onAction = {
+                                    (requireActivity() as MainActivity).changeFragment(MateFragment())
+                                }
+                            )
+                            UiEffect.ShowClapAnimation -> {
+                                (requireActivity() as MainActivity).startCongratulateThirdClapAnimation { viewModel.checkLevelUpHabit() }
+                            }
                             UiEffect.ShowNotiRecommendBottomSheet -> showNotiRecommendBottomSheet()
                             UiEffect.ShowNotiGuideBottomSheet -> checkNotificationPermission()
                         }

--- a/presentation/home/src/main/java/com/depromeet/threedays/home/home/HomeFragment.kt
+++ b/presentation/home/src/main/java/com/depromeet/threedays/home/home/HomeFragment.kt
@@ -106,9 +106,7 @@ class HomeFragment : BaseFragment<FragmentHomeBinding, HomeViewModel>(R.layout.f
 
     private fun initAdapter() {
         habitAdapter = HabitAdapter(
-            createHabitAchievement = { habitId, isThirdClap ->
-                viewModel.createHabitAchievement(habitId, isThirdClap)
-            },
+            createHabitAchievement = { viewModel.createHabitAchievement(it) },
             deleteHabitAchievement = { habitId, habitAchievementId ->
                 viewModel.deleteHabitAchievement(
                     habitId = habitId,

--- a/presentation/home/src/main/java/com/depromeet/threedays/home/home/HomeFragment.kt
+++ b/presentation/home/src/main/java/com/depromeet/threedays/home/home/HomeFragment.kt
@@ -314,8 +314,8 @@ class HomeFragment : BaseFragment<FragmentHomeBinding, HomeViewModel>(R.layout.f
                                     (requireActivity() as MainActivity).changeFragment(MateFragment())
                                 }
                             )
-                            UiEffect.ShowClapAnimation -> {
-                                (requireActivity() as MainActivity).startCongratulateThirdClapAnimation { viewModel.checkLevelUpHabit() }
+                            is UiEffect.ShowClapAnimation -> {
+                                (requireActivity() as MainActivity).startCongratulateThirdClapAnimation { viewModel.checkLevelUpHabit(it.habitId) }
                             }
                             UiEffect.ShowNotiRecommendBottomSheet -> showNotiRecommendBottomSheet()
                             UiEffect.ShowNotiGuideBottomSheet -> checkNotificationPermission()

--- a/presentation/home/src/main/java/com/depromeet/threedays/home/home/HomeViewModel.kt
+++ b/presentation/home/src/main/java/com/depromeet/threedays/home/home/HomeViewModel.kt
@@ -86,7 +86,7 @@ class HomeViewModel @Inject constructor(
         }
     }
 
-    fun createHabitAchievement(habitId: Long, isThirdClap: Boolean) {
+    fun createHabitAchievement(habitId: Long) {
         viewModelScope.launch {
             createHabitAchievementUseCase(habitId).collect { response ->
                 when(response.status) {

--- a/presentation/home/src/main/java/com/depromeet/threedays/home/home/HomeViewModel.kt
+++ b/presentation/home/src/main/java/com/depromeet/threedays/home/home/HomeViewModel.kt
@@ -15,6 +15,7 @@ import com.depromeet.threedays.domain.usecase.today_visit.WriteTodayFirstVisitUs
 import com.depromeet.threedays.home.R
 import com.depromeet.threedays.home.home.model.HabitUI
 import com.depromeet.threedays.home.home.model.toHabitUI
+import com.depromeet.threedays.mate.MateImageResourceResolver.Companion.levelToResourceFunction
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
@@ -253,6 +254,27 @@ class HomeViewModel @Inject constructor(
             }
         }
     }
+
+    fun checkLevelUpHabit() {
+        val habitWithMate = habits.value.find { it.mate != null } ?: return
+        val mate = habitWithMate.mate ?: return
+        val levelUpAt = mate.levelUpAt ?: return
+
+        val today = LocalDate.now().toString()
+        if(today == levelUpAt.toLocalDate().toString()) {
+            viewModelScope.launch {
+                _uiEffect.emit(
+                    UiEffect.ShowImageSnackBar(
+                        imageResId = levelToResourceFunction(mate.level),
+                        titleResId = R.string.level_up_title,
+                        contentResId = R.string.level_up_content,
+                        actionTextResId = R.string.move,
+                        mateLevel = mate.level,
+                    )
+                )
+            }
+        }
+    }
 }
 
 sealed interface UiEffect {
@@ -270,6 +292,13 @@ sealed interface UiEffect {
         val textResId: Int,
         val actionTextResId: Int,
     ): UiEffect
+    data class ShowImageSnackBar(
+        val imageResId: Int,
+        val titleResId: Int,
+        val contentResId: Int,
+        val actionTextResId: Int,
+        val mateLevel: Int,
+    ) : UiEffect
     object ShowClapAnimation : UiEffect
     object ShowNotiGuideBottomSheet : UiEffect
     object ShowNotiRecommendBottomSheet : UiEffect

--- a/presentation/home/src/main/res/layout/activity_main.xml
+++ b/presentation/home/src/main/res/layout/activity_main.xml
@@ -55,6 +55,19 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
+        <ImageView
+            android:id="@+id/iv_close"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="30dp"
+            android:layout_marginEnd="20dp"
+            android:elevation="10dp"
+            android:src="@drawable/selector_popup_close"
+            android:visibility="gone"
+            app:elevation="10dp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
         <com.airbnb.lottie.LottieAnimationView
             android:id="@+id/lottie_clap"
             android:layout_width="240dp"
@@ -80,15 +93,5 @@
             app:layout_constraintEnd_toEndOf="@+id/lottie_clap"
             app:layout_constraintStart_toStartOf="@+id/lottie_clap"
             app:layout_constraintTop_toBottomOf="@+id/lottie_clap" />
-
-        <ImageView
-            android:id="@+id/iv_close"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="30dp"
-            android:layout_marginEnd="20dp"
-            android:src="@drawable/selector_popup_close"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/presentation/home/src/main/res/layout/activity_main.xml
+++ b/presentation/home/src/main/res/layout/activity_main.xml
@@ -29,12 +29,12 @@
             android:id="@+id/bnv_main"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            app:itemTextAppearanceActive="@style/BottomNavigationView.Active"
-            app:itemTextAppearanceInactive="@style/BottomNavigationView"
-            app:labelVisibilityMode="labeled"
             app:elevation="0dp"
             app:itemIconTint="@drawable/selector_menu_color"
+            app:itemTextAppearanceActive="@style/BottomNavigationView.Active"
+            app:itemTextAppearanceInactive="@style/BottomNavigationView"
             app:itemTextColor="@drawable/selector_menu_color"
+            app:labelVisibilityMode="labeled"
             app:layout_constraintBottom_toBottomOf="parent"
             app:menu="@menu/bottom_nav_menu"/>
 
@@ -43,7 +43,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:visibility="gone"
-            app:constraint_referenced_ids="view_background_for_animation, lottie_clap, tv_congratulation_for_third_clap" />
+            app:constraint_referenced_ids="view_background_for_animation, lottie_clap, tv_congratulation_for_third_clap, iv_close" />
 
         <View
             android:id="@+id/view_background_for_animation"
@@ -80,5 +80,15 @@
             app:layout_constraintEnd_toEndOf="@+id/lottie_clap"
             app:layout_constraintStart_toStartOf="@+id/lottie_clap"
             app:layout_constraintTop_toBottomOf="@+id/lottie_clap" />
+
+        <ImageView
+            android:id="@+id/iv_close"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="30dp"
+            android:layout_marginEnd="20dp"
+            android:src="@drawable/selector_popup_close"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/presentation/home/src/main/res/values/strings.xml
+++ b/presentation/home/src/main/res/values/strings.xml
@@ -20,6 +20,8 @@
     <string name="move">이동</string>
     <string name="snack_bar_text_has_achievement">습관이 홈에서 삭제됐어요.\n실천 기록이 있어 보관함으로 이동됐어요.</string>
     <string name="snack_bar_text_connected_mate">습관이 홈에서 삭제됐어요.\n짝꿍과 실천 기록은 보관함으로 이동됐어요.</string>
+    <string name="level_up_title">레벨 업</string>
+    <string name="level_up_content">Lv.%d 로 레벨업 했어요!</string>
 
     <!-- 알림 권유 -->
     <string name="noti_recommend_title">셀프 잔소리로 동기부여까지</string>

--- a/presentation/mate/src/main/java/com/depromeet/threedays/mate/create/step1/model/MateUI.kt
+++ b/presentation/mate/src/main/java/com/depromeet/threedays/mate/create/step1/model/MateUI.kt
@@ -11,7 +11,7 @@ data class MateUI(
     val habitId: Long,
     val memberId: Long,
     val title: String,
-    val createAt: LocalDateTime,
+    val createAt: LocalDateTime?, // TODO: null로 들어와서 임시 조치
     val level: Int,
     val reward: Int?,
     val rewardHistory: List<RewardHistoryUI>?,
@@ -22,7 +22,7 @@ data class MateUI(
     val status: String,
 ) : MateImageResourceResolver {
     data class RewardHistoryUI(
-        val createAt: LocalDateTime,
+        val createAt: LocalDateTime?,
     )
 
     override fun resolveMateImageResource(): Int {


### PR DESCRIPTION
## 💁‍♂️ 변경 내용
### AS-IS
- 세번째 박수를 치면 취소를 할 수 없었습니다. (다음날 된것처럼 넘어감)
- 세번째 박수를 쳐도 애니메이션이 나오지 않습니다.
- 세번째 박수 이후 스낵바가 뜨지 않았습니다.

### TO-BE
- 세번째 박수를 쳐도 취소를 할 수 있습니다.
- 세번째 박수를 치면 애니메이션이 나옵니다. (취소했다가 다시 누르면 다시 뜸)
- 세번째 박수 이후 스낵바가 뜨며 이동 클릭시 짝꿍 페이지로 이동합니다.

## 📢 전달사항
12시 이전에는 박수랑 체크표시만 변동이 생기고
애니메이션이랑 짝꿍 레벨업 스낵바는 다음날 접속해야 뜨게 하고 싶었는데
애초에 서버에서도 12시에 배치 돌리는 게 아니라 바로 박수 + 1, 레벨업 + 1 해줘서
구현하기가 어렵더라고요..
datastore에 정보 저장해서 어떻게 해결해보려고 했는데 시간이 너무 오래 걸려서
체크 즉시 이벤트들이 발생하도록 수정했습니다.