### PR TITLE
DEP-382 fix: 회원가입과 fcmToken 등록이 동시에 실행되는 현상 해결

### DIFF
--- a/presentation/signup/src/main/java/com/depromeet/threedays/signup/SignupActivity.kt
+++ b/presentation/signup/src/main/java/com/depromeet/threedays/signup/SignupActivity.kt
@@ -59,10 +59,7 @@ class SignupActivity: BaseActivity<ActivitySignupBinding>(R.layout.activity_sign
                 }.onSuccess { oAuthToken ->
                     UserApiClient.instance.me { user, _ ->
                         if (user != null) {
-                            viewModel.createMember(
-                                socialToken = oAuthToken.accessToken
-                            )
-                            viewModel.updateFcmToken()
+                            viewModel.createMember(socialToken = oAuthToken.accessToken)
                         }
                     }
                 }.onFailure { throwable ->

--- a/presentation/signup/src/main/java/com/depromeet/threedays/signup/SignupViewModel.kt
+++ b/presentation/signup/src/main/java/com/depromeet/threedays/signup/SignupViewModel.kt
@@ -7,9 +7,7 @@ import androidx.lifecycle.viewModelScope
 import com.depromeet.threedays.core.BaseViewModel
 import com.depromeet.threedays.domain.entity.auth.SignupMember
 import com.depromeet.threedays.domain.entity.member.AuthenticationProvider
-import com.depromeet.threedays.domain.repository.NotificationTokenRepository
 import com.depromeet.threedays.domain.usecase.auth.CreateMemberUserCase
-import com.depromeet.threedays.domain.usecase.notification.token.UpdateNotificationTokenUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -21,8 +19,6 @@ import javax.inject.Inject
 @HiltViewModel
 class SignupViewModel @Inject constructor(
     private val createMemberUserCase: CreateMemberUserCase,
-    private val notificationTokenRepository: NotificationTokenRepository,
-    private val updateNotificationTokenUseCase: UpdateNotificationTokenUseCase,
 ) : BaseViewModel() {
 
    private val _action = MutableSharedFlow<Action>()
@@ -48,17 +44,6 @@ class SignupViewModel @Inject constructor(
             }.onFailure { throwable ->
                 Timber.e("--- SignupViewModel - Signup error: ${throwable.message}")
             }
-        }
-    }
-
-    fun updateFcmToken() {
-        viewModelScope.launch {
-            notificationTokenRepository.getToken()
-                ?.runCatching {
-                    updateNotificationTokenUseCase(notificationToken = this)
-                }?.onFailure { e ->
-                    Timber.e(e, "Failed to update registration token")
-                }
         }
     }
 

--- a/presentation/signup/src/main/java/com/depromeet/threedays/signup/complete/SignupCompleteActivity.kt
+++ b/presentation/signup/src/main/java/com/depromeet/threedays/signup/complete/SignupCompleteActivity.kt
@@ -1,6 +1,7 @@
 package com.depromeet.threedays.signup.complete
 
 import android.os.Bundle
+import androidx.activity.viewModels
 import com.depromeet.threedays.core.BaseActivity
 import com.depromeet.threedays.core.util.setOnSingleClickListener
 import com.depromeet.threedays.navigator.HomeNavigator
@@ -11,12 +12,14 @@ import javax.inject.Inject
 
 @AndroidEntryPoint
 class SignupCompleteActivity : BaseActivity<ActivitySignupCompleteBinding>(R.layout.activity_signup_complete) {
+    private val viewModel by viewModels<SignupCompleteViewModel>()
 
     @Inject
     lateinit var homeNavigator: HomeNavigator
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        viewModel.updateFcmToken()
         initView()
     }
 

--- a/presentation/signup/src/main/java/com/depromeet/threedays/signup/complete/SignupCompleteViewModel.kt
+++ b/presentation/signup/src/main/java/com/depromeet/threedays/signup/complete/SignupCompleteViewModel.kt
@@ -1,0 +1,31 @@
+package com.depromeet.threedays.signup.complete
+
+import androidx.lifecycle.viewModelScope
+import com.depromeet.threedays.core.BaseViewModel
+import com.depromeet.threedays.domain.repository.NotificationTokenRepository
+import com.depromeet.threedays.domain.usecase.notification.token.UpdateNotificationTokenUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import timber.log.Timber
+import javax.inject.Inject
+
+@HiltViewModel
+class SignupCompleteViewModel @Inject constructor(
+    private val notificationTokenRepository: NotificationTokenRepository,
+    private val updateNotificationTokenUseCase: UpdateNotificationTokenUseCase,
+) : BaseViewModel() {
+
+    /**
+     * 회원 가입 성공시 fcmToken 을 서버로 전송
+     */
+    fun updateFcmToken() {
+        viewModelScope.launch {
+            notificationTokenRepository.getToken()
+                ?.runCatching {
+                    updateNotificationTokenUseCase(notificationToken = this)
+                }?.onFailure { e ->
+                    Timber.e(e, "Failed to update registration token")
+                }
+        }
+    }
+}


### PR DESCRIPTION
## 💁‍♂️ 변경 내용
### AS-IS
- 회원가입이 끝나기 전에 fcmToken update api 를 호출하면서, 401 에러 발생함
### TO-BE
- SignupComplete 화면에서 fcmToken 등록하게 변경
## 📢 전달사항
