### PR TITLE
DEP-000 fix: 페이지 이동 후 activity 닫기

### DIFF
--- a/presentation/mypage/src/main/java/com/depromeet/threedays/mypage/MyPageFragment.kt
+++ b/presentation/mypage/src/main/java/com/depromeet/threedays/mypage/MyPageFragment.kt
@@ -95,6 +95,7 @@ class MyPageFragment :
                     viewModel.logoutSucceed.collect { logoutSucceed ->
                         if (logoutSucceed) {
                             startActivity(signupNavigator.intent(requireContext()))
+                            activity?.finish()
                         }
                     }
                 }
@@ -102,6 +103,7 @@ class MyPageFragment :
                     viewModel.signoutSucceed.collect { signoutSucceed ->
                         if (signoutSucceed) {
                             startActivity(signupNavigator.intent(requireContext()))
+                            activity?.finish()
                         }
                     }
                 }


### PR DESCRIPTION
## 💁‍♂️ 변경 내용
### AS-IS
- 로그아웃후 로그인페이지에 가서 뒤로 버튼을 누르면 계속 로그인 페이지로 이동함 (버그)
### TO-BE
- 로그아웃후 로그인페이지에 가서 뒤로 버튼을 누르면 앱이 종료됨 
## 📢 전달사항
