### PR TITLE
feat: mixpanel project token 환경별로 분리

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -45,6 +45,7 @@ android {
             ]
             buildConfigField 'String', 'BASE_URL', "\"${properties.getProperty('release.three-days.base-url')}\""
             buildConfigField 'String', 'KAKAO_APP_KEY', "\"${properties.getProperty('release.kakao.app-key')}\""
+            buildConfigField 'String', 'MIXPANEL_PROJECT_TOKEN', "\"${properties.getProperty('release.mixpanel.project-token')}\""
         }
         debug {
             applicationIdSuffix '.debug'
@@ -53,6 +54,7 @@ android {
             ]
             buildConfigField 'String', 'BASE_URL', "\"${properties.getProperty('debug.three-days.base-url')}\""
             buildConfigField 'String', 'KAKAO_APP_KEY', "\"${properties.getProperty('debug.kakao.app-key')}\""
+            buildConfigField 'String', 'MIXPANEL_PROJECT_TOKEN', "\"${properties.getProperty('debug.mixpanel.project-token')}\""
         }
         alpha {
             initWith debug

--- a/build-property/src/main/java/com/depromeet/threedays/buildproperty/BuildProperty.kt
+++ b/build-property/src/main/java/com/depromeet/threedays/buildproperty/BuildProperty.kt
@@ -8,6 +8,7 @@ enum class BuildProperty(
 ) {
     BASE_URL("api 서버 주소"),
     KAKAO_APP_KEY("Kakao native app key"),
+    MIXPANEL_PROJECT_TOKEN("Mixpanel project token")
     ;
 
     /**

--- a/core/src/main/java/com/depromeet/threedays/core/analytics/MixpanelAnalyticsSdk.kt
+++ b/core/src/main/java/com/depromeet/threedays/core/analytics/MixpanelAnalyticsSdk.kt
@@ -1,6 +1,7 @@
 package com.depromeet.threedays.core.analytics
 
 import android.content.Context
+import com.depromeet.threedays.buildproperty.BuildProperty
 import com.mixpanel.android.mpmetrics.MixpanelAPI
 import org.json.JSONObject
 import timber.log.Timber
@@ -10,8 +11,22 @@ class MixpanelAnalyticsSdk : AnalyticsSdk {
     private var initialized = false
 
     override fun init(context: Context) {
-        mixpanelAPI = MixpanelAPI.getInstance(context, "823f0e71338dd687bbe4d1b2f34e1272", true)
+        val projectToken = resolveToken(context)
+        mixpanelAPI = MixpanelAPI.getInstance(context, projectToken, true)
         initialized = true
+    }
+
+    // FIXME: DI 받아서 접근하도록 변경
+    private fun resolveToken(context: Context): String {
+        return try {
+            context.classLoader
+                .loadClass("com.depromeet.threedays.BuildConfig")
+                .getDeclaredField(BuildProperty.MIXPANEL_PROJECT_TOKEN.name)
+                .get(null) as String
+        } catch (e: Exception) {
+            Timber.e(e, "Failed to resolve mixpanel project token")
+            throw e
+        }
     }
 
     override fun isInitialized(): Boolean = initialized


### PR DESCRIPTION
## 💁‍♂️ 변경 내용
### AS-IS
- project token 값을 debug, release 동일하게 사용
### TO-BE
- `local.properties`에 저장된 토큰 값을 읽어 debug, release 환경에 맞게 주입

## 📢 전달사항
- `app -> core` 방향으로 모듈이 의존하고있어서 컴파일타입에 `core` 모듈에서 `app` 모듈의 `BuildConfig` 에 접근하지 못함. 런타임에 classLoader 사용해서 `core` 모듈에서 `app` 모듈의 `BuildConfig` 클래스 접근 및 값 조회했습니다. 
  - 추후 Dependnecy Injection 사용하도록 변경해서 리플렉션 없애볼게요..
