### PR TITLE
DEP-368 fix: mixpanel 이벤트 발행 오류

### DIFF
--- a/core/src/main/java/com/depromeet/threedays/core/analytics/ThreeDaysEvent.kt
+++ b/core/src/main/java/com/depromeet/threedays/core/analytics/ThreeDaysEvent.kt
@@ -27,6 +27,7 @@ enum class Screen {
     MateCompleted,
     MateShare,
     MateMaking,
+    Push
 }
 
 enum class ThreeDaysEvent {
@@ -53,4 +54,5 @@ enum class ThreeDaysEvent {
     MateLevelupViewed,
     MateCompletedViewed,
     MateSaveClicked,
+    PushViewed
 }

--- a/presentation/home/src/main/java/com/depromeet/threedays/home/home/HomeFragment.kt
+++ b/presentation/home/src/main/java/com/depromeet/threedays/home/home/HomeFragment.kt
@@ -230,13 +230,6 @@ class HomeFragment : BaseFragment<FragmentHomeBinding, HomeViewModel>(R.layout.f
     }
 
     private fun showNotiRecommendBottomSheet() {
-        AnalyticsUtil.event(
-            name = ThreeDaysEvent.PushViewed.toString(),
-            properties = mapOf(
-                MixPanelEvent.ScreenName to Screen.Push.toString()
-            )
-        )
-
         val modal = NotiRecommendBottomSheet(
             onConfirmClick = { checkNotificationPermission() }
         )
@@ -245,14 +238,6 @@ class HomeFragment : BaseFragment<FragmentHomeBinding, HomeViewModel>(R.layout.f
     }
 
     private fun checkNotificationPermission() {
-        AnalyticsUtil.event(
-            name = ThreeDaysEvent.ButtonClicked.toString(),
-            properties = mapOf(
-                MixPanelEvent.ScreenName to Screen.Push.toString(),
-                MixPanelEvent.ButtonType to ButtonType.Next.toString()
-            )
-        )
-
         val isDeviceNotificationOn = NotificationManagerCompat.from(requireContext()).areNotificationsEnabled()
         if(!isDeviceNotificationOn) {
             NotiGuideBottomSheet.newInstance (

--- a/presentation/home/src/main/java/com/depromeet/threedays/home/home/HomeFragment.kt
+++ b/presentation/home/src/main/java/com/depromeet/threedays/home/home/HomeFragment.kt
@@ -251,23 +251,20 @@ class HomeFragment : BaseFragment<FragmentHomeBinding, HomeViewModel>(R.layout.f
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 launch {
                     viewModel.habits.collect { list ->
-                        if(!viewModel.isInitialized) {
-                            if (list.isEmpty()) {
-                                AnalyticsUtil.event(
-                                    name = ThreeDaysEvent.HomeDefaultViewed.toString(),
-                                    properties = mapOf(
-                                        MixPanelEvent.ScreenName to Screen.HomeDefault.toString()
-                                    )
+                        if (list.isEmpty()) {
+                            AnalyticsUtil.event(
+                                name = ThreeDaysEvent.HomeDefaultViewed.toString(),
+                                properties = mapOf(
+                                    MixPanelEvent.ScreenName to Screen.HomeDefault.toString()
                                 )
-                            } else {
-                                AnalyticsUtil.event(
-                                    name = ThreeDaysEvent.HomeActivatedViewed.toString(),
-                                    properties = mapOf(
-                                        MixPanelEvent.ScreenName to Screen.HomeActivated.toString()
-                                    )
+                            )
+                        } else {
+                            AnalyticsUtil.event(
+                                name = ThreeDaysEvent.HomeActivatedViewed.toString(),
+                                properties = mapOf(
+                                    MixPanelEvent.ScreenName to Screen.HomeActivated.toString()
                                 )
-                            }
-                            viewModel.isInitialized = true
+                            )
                         }
 
                         habitAdapter.submitList(list.sortedBy { it.createAt })

--- a/presentation/home/src/main/java/com/depromeet/threedays/home/home/HomeFragment.kt
+++ b/presentation/home/src/main/java/com/depromeet/threedays/home/home/HomeFragment.kt
@@ -24,18 +24,21 @@ import com.depromeet.threedays.domain.key.RESULT_CREATE
 import com.depromeet.threedays.domain.key.RESULT_UPDATE
 import com.depromeet.threedays.home.MainActivity
 import com.depromeet.threedays.home.R
-import com.depromeet.threedays.core_design_system.R as core_design
 import com.depromeet.threedays.home.databinding.FragmentHomeBinding
 import com.depromeet.threedays.home.home.dialog.MoreActionModal
 import com.depromeet.threedays.home.home.dialog.NotiGuideBottomSheet
 import com.depromeet.threedays.home.home.dialog.NotiRecommendBottomSheet
 import com.depromeet.threedays.mate.MateFragment
-import com.depromeet.threedays.navigator.*
+import com.depromeet.threedays.navigator.ArchivedHabitNavigator
+import com.depromeet.threedays.navigator.HabitCreateNavigator
+import com.depromeet.threedays.navigator.HabitUpdateNavigator
+import com.depromeet.threedays.navigator.NotificationNavigator
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 import java.time.ZoneId
 import java.time.ZonedDateTime
 import javax.inject.Inject
+import com.depromeet.threedays.core_design_system.R as core_design
 
 @AndroidEntryPoint
 class HomeFragment : BaseFragment<FragmentHomeBinding, HomeViewModel>(R.layout.fragment_home) {
@@ -80,9 +83,9 @@ class HomeFragment : BaseFragment<FragmentHomeBinding, HomeViewModel>(R.layout.f
     private fun onCreateHabitClick() {
         if(viewModel.habits.value.isEmpty()) {
             AnalyticsUtil.event(
-                name = ThreeDaysEvent.NewMateClicked.toString(),
+                name = ThreeDaysEvent.NewHabitClicked.toString(),
                 properties = mapOf(
-                    MixPanelEvent.ScreenName to Screen.HomeDefault,
+                    MixPanelEvent.ScreenName to Screen.HomeDefault.toString(),
                     MixPanelEvent.ButtonType to ButtonType.NewHabit.toString()
                 )
             )
@@ -248,21 +251,23 @@ class HomeFragment : BaseFragment<FragmentHomeBinding, HomeViewModel>(R.layout.f
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 launch {
                     viewModel.habits.collect { list ->
-                        if(list.isNotEmpty()) {
-                            AnalyticsUtil.event(
-                                name = ThreeDaysEvent.HomeDefaultViewed.toString(),
-                                properties = mapOf(
-                                    MixPanelEvent.ScreenName to Screen.HomeDefault.toString()
+                        if(!viewModel.isInitialized) {
+                            if (list.isEmpty()) {
+                                AnalyticsUtil.event(
+                                    name = ThreeDaysEvent.HomeDefaultViewed.toString(),
+                                    properties = mapOf(
+                                        MixPanelEvent.ScreenName to Screen.HomeDefault.toString()
+                                    )
                                 )
-                            )
-                        }
-                        else {
-                            AnalyticsUtil.event(
-                                name = ThreeDaysEvent.HomeActivatedViewed.toString(),
-                                properties = mapOf(
-                                    MixPanelEvent.ScreenName to Screen.HomeActivated.toString()
+                            } else {
+                                AnalyticsUtil.event(
+                                    name = ThreeDaysEvent.HomeActivatedViewed.toString(),
+                                    properties = mapOf(
+                                        MixPanelEvent.ScreenName to Screen.HomeActivated.toString()
+                                    )
                                 )
-                            )
+                            }
+                            viewModel.isInitialized = true
                         }
 
                         habitAdapter.submitList(list.sortedBy { it.createAt })

--- a/presentation/home/src/main/java/com/depromeet/threedays/home/home/HomeFragment.kt
+++ b/presentation/home/src/main/java/com/depromeet/threedays/home/home/HomeFragment.kt
@@ -230,6 +230,13 @@ class HomeFragment : BaseFragment<FragmentHomeBinding, HomeViewModel>(R.layout.f
     }
 
     private fun showNotiRecommendBottomSheet() {
+        AnalyticsUtil.event(
+            name = ThreeDaysEvent.PushViewed.toString(),
+            properties = mapOf(
+                MixPanelEvent.ScreenName to Screen.Push.toString()
+            )
+        )
+
         val modal = NotiRecommendBottomSheet(
             onConfirmClick = { checkNotificationPermission() }
         )
@@ -238,6 +245,14 @@ class HomeFragment : BaseFragment<FragmentHomeBinding, HomeViewModel>(R.layout.f
     }
 
     private fun checkNotificationPermission() {
+        AnalyticsUtil.event(
+            name = ThreeDaysEvent.ButtonClicked.toString(),
+            properties = mapOf(
+                MixPanelEvent.ScreenName to Screen.Push.toString(),
+                MixPanelEvent.ButtonType to ButtonType.Next.toString()
+            )
+        )
+
         val isDeviceNotificationOn = NotificationManagerCompat.from(requireContext()).areNotificationsEnabled()
         if(!isDeviceNotificationOn) {
             NotiGuideBottomSheet.newInstance (

--- a/presentation/home/src/main/java/com/depromeet/threedays/home/home/HomeViewModel.kt
+++ b/presentation/home/src/main/java/com/depromeet/threedays/home/home/HomeViewModel.kt
@@ -15,7 +15,10 @@ import com.depromeet.threedays.home.home.model.HabitUI
 import com.depromeet.threedays.home.home.model.toHabitUI
 import com.depromeet.threedays.mate.MateImageResourceResolver.Companion.levelToResourceFunction
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import java.time.LocalDate
 import javax.inject.Inject
@@ -37,6 +40,8 @@ class HomeViewModel @Inject constructor(
     private val _uiEffect: MutableSharedFlow<UiEffect> = MutableSharedFlow()
     val uiEffect: SharedFlow<UiEffect>
         get() = _uiEffect
+
+    var isInitialized: Boolean = false
 
     init {
         fetchGoals()

--- a/presentation/home/src/main/java/com/depromeet/threedays/home/home/HomeViewModel.kt
+++ b/presentation/home/src/main/java/com/depromeet/threedays/home/home/HomeViewModel.kt
@@ -41,8 +41,6 @@ class HomeViewModel @Inject constructor(
     val uiEffect: SharedFlow<UiEffect>
         get() = _uiEffect
 
-    var isInitialized: Boolean = false
-
     init {
         fetchGoals()
         checkIsFirstVisitor()

--- a/presentation/home/src/main/java/com/depromeet/threedays/home/home/dialog/NotiRecommendBottomSheet.kt
+++ b/presentation/home/src/main/java/com/depromeet/threedays/home/home/dialog/NotiRecommendBottomSheet.kt
@@ -5,6 +5,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
+import com.depromeet.threedays.core.analytics.*
 import com.depromeet.threedays.core.util.setOnSingleClickListener
 import com.depromeet.threedays.home.R
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
@@ -17,6 +18,13 @@ class NotiRecommendBottomSheet(
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
+        AnalyticsUtil.event(
+            name = ThreeDaysEvent.PushViewed.toString(),
+            properties = mapOf(
+                MixPanelEvent.ScreenName to Screen.Push.toString()
+            )
+        )
+
         super.onCreateView(inflater, container, savedInstanceState)
         return inflater.inflate(R.layout.bottom_sheet_noti_recommend, container, false)
     }
@@ -26,6 +34,13 @@ class NotiRecommendBottomSheet(
 
         val btnConfirm = view.findViewById<Button>(R.id.btn_confirm)
         btnConfirm.setOnSingleClickListener {
+            AnalyticsUtil.event(
+                name = ThreeDaysEvent.ButtonClicked.toString(),
+                properties = mapOf(
+                    MixPanelEvent.ScreenName to Screen.Push.toString(),
+                    MixPanelEvent.ButtonType to ButtonType.Next.toString()
+                )
+            )
             dismiss()
             onConfirmClick()
         }

--- a/presentation/mate/src/main/java/com/depromeet/threedays/mate/MateFragment.kt
+++ b/presentation/mate/src/main/java/com/depromeet/threedays/mate/MateFragment.kt
@@ -86,8 +86,8 @@ class MateFragment: BaseFragment<FragmentMateBinding, MateViewModel>(R.layout.fr
             AnalyticsUtil.event(
                 name = ThreeDaysEvent.MateDefaultViewed.toString(),
                 properties = mapOf(
-                    MixPanelEvent.ScreenName to Screen.MateDefault,
-                    MixPanelEvent.ButtonType to ButtonType.NewMate,
+                    MixPanelEvent.ScreenName to Screen.MateDefault.toString(),
+                    MixPanelEvent.ButtonType to ButtonType.NewMate.toString(),
                 )
             )
 
@@ -99,8 +99,8 @@ class MateFragment: BaseFragment<FragmentMateBinding, MateViewModel>(R.layout.fr
             AnalyticsUtil.event(
                 name = ThreeDaysEvent.MateShareClicked.toString(),
                 properties = mapOf(
-                    MixPanelEvent.ScreenName to Screen.MateHome,
-                    MixPanelEvent.ButtonType to ButtonType.Share,
+                    MixPanelEvent.ScreenName to Screen.MateHome.toString(),
+                    MixPanelEvent.ButtonType to ButtonType.Share.toString(),
                 )
             )
 
@@ -139,8 +139,8 @@ class MateFragment: BaseFragment<FragmentMateBinding, MateViewModel>(R.layout.fr
             AnalyticsUtil.event(
                 name = ThreeDaysEvent.MateSaveClicked.toString(),
                 properties = mapOf(
-                    MixPanelEvent.ScreenName to Screen.MateCompleted,
-                    MixPanelEvent.ButtonType to ButtonType.MateSave,
+                    MixPanelEvent.ScreenName to Screen.MateCompleted.toString(),
+                    MixPanelEvent.ButtonType to ButtonType.MateSave.toString(),
                 )
             )
 
@@ -175,8 +175,8 @@ class MateFragment: BaseFragment<FragmentMateBinding, MateViewModel>(R.layout.fr
                         AnalyticsUtil.event(
                             name = ThreeDaysEvent.MateClapOpenClicked.toString(),
                             properties = mapOf(
-                                MixPanelEvent.ScreenName to Screen.MateDefault,
-                                MixPanelEvent.ButtonType to ButtonType.MateClapOpen,
+                                MixPanelEvent.ScreenName to Screen.MateDefault.toString(),
+                                MixPanelEvent.ButtonType to ButtonType.MateClapOpen.toString(),
                             )
                         )
                         binding.ivArrow.setImageResource(core_design.drawable.ic_arrow_down)
@@ -264,7 +264,7 @@ class MateFragment: BaseFragment<FragmentMateBinding, MateViewModel>(R.layout.fr
                 AnalyticsUtil.event(
                     name = ThreeDaysEvent.MateCompletedViewed.toString(),
                     properties = mapOf(
-                        MixPanelEvent.ScreenName to Screen.MateCompleted,
+                        MixPanelEvent.ScreenName to Screen.MateCompleted.toString(),
                     )
                 )
 
@@ -315,7 +315,7 @@ class MateFragment: BaseFragment<FragmentMateBinding, MateViewModel>(R.layout.fr
         AnalyticsUtil.event(
             name = ThreeDaysEvent.MateLevelupViewed.toString(),
             properties = mapOf(
-                MixPanelEvent.ScreenName to Screen.MateLevelup,
+                MixPanelEvent.ScreenName to Screen.MateLevelup.toString(),
             )
         )
 
@@ -332,14 +332,14 @@ class MateFragment: BaseFragment<FragmentMateBinding, MateViewModel>(R.layout.fr
             AnalyticsUtil.event(
                 name = ThreeDaysEvent.MateHomeViewed.toString(),
                 properties = mapOf(
-                    MixPanelEvent.ScreenName to Screen.MateHome,
+                    MixPanelEvent.ScreenName to Screen.MateHome.toString(),
                 )
             )
         } else {
             AnalyticsUtil.event(
                 name = ThreeDaysEvent.MateDefaultViewed.toString(),
                 properties = mapOf(
-                    MixPanelEvent.ScreenName to Screen.MateDefault,
+                    MixPanelEvent.ScreenName to Screen.MateDefault.toString(),
                 )
             )
         }

--- a/presentation/mate/src/main/java/com/depromeet/threedays/mate/create/step1/ConnectHabitActivity.kt
+++ b/presentation/mate/src/main/java/com/depromeet/threedays/mate/create/step1/ConnectHabitActivity.kt
@@ -12,8 +12,8 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.depromeet.threedays.core.BaseActivity
 import com.depromeet.threedays.core.analytics.*
-import com.depromeet.threedays.core.util.setOnSingleClickListener
 import com.depromeet.threedays.core.util.dpToPx
+import com.depromeet.threedays.core.util.setOnSingleClickListener
 import com.depromeet.threedays.mate.R
 import com.depromeet.threedays.mate.create.step2.ChooseMateTypeActivity
 import com.depromeet.threedays.mate.databinding.ActivityConnectHabitBinding
@@ -70,7 +70,7 @@ class ConnectHabitActivity : BaseActivity<ActivityConnectHabitBinding>(R.layout.
                 name = ThreeDaysEvent.ButtonClicked.toString(),
                 properties = mapOf(
                     MixPanelEvent.ScreenName to "${Screen.MateMaking}1",
-                    MixPanelEvent.ButtonType to ButtonType.Next,
+                    MixPanelEvent.ButtonType to ButtonType.Next.toString(),
                 )
             )
 

--- a/presentation/mate/src/main/java/com/depromeet/threedays/mate/create/step2/ChooseMateTypeActivity.kt
+++ b/presentation/mate/src/main/java/com/depromeet/threedays/mate/create/step2/ChooseMateTypeActivity.kt
@@ -45,7 +45,7 @@ class ChooseMateTypeActivity : BaseActivity<ActivityChooseMateTypeBinding>(R.lay
                 name = ThreeDaysEvent.MateSelected.toString(),
                 properties = mapOf(
                     MixPanelEvent.ScreenName to "${Screen.MateMaking}2",
-                    MixPanelEvent.ButtonType to ButtonType.Sparta,
+                    MixPanelEvent.ButtonType to ButtonType.Sparta.toString(),
                 )
             )
 
@@ -56,7 +56,7 @@ class ChooseMateTypeActivity : BaseActivity<ActivityChooseMateTypeBinding>(R.lay
                 name = ThreeDaysEvent.MateSelected.toString(),
                 properties = mapOf(
                     MixPanelEvent.ScreenName to "${Screen.MateMaking}2",
-                    MixPanelEvent.ButtonType to ButtonType.Carrot,
+                    MixPanelEvent.ButtonType to ButtonType.Carrot.toString(),
                 )
             )
 
@@ -70,7 +70,7 @@ class ChooseMateTypeActivity : BaseActivity<ActivityChooseMateTypeBinding>(R.lay
                 name = ThreeDaysEvent.ButtonClicked.toString(),
                 properties = mapOf(
                     MixPanelEvent.ScreenName to "${Screen.MateMaking}2",
-                    MixPanelEvent.ButtonType to ButtonType.Next,
+                    MixPanelEvent.ButtonType to ButtonType.Next.toString(),
                 )
             )
 

--- a/presentation/mate/src/main/java/com/depromeet/threedays/mate/create/step3/SetMateNicknameActivity.kt
+++ b/presentation/mate/src/main/java/com/depromeet/threedays/mate/create/step3/SetMateNicknameActivity.kt
@@ -66,7 +66,7 @@ class SetMateNicknameActivity : BaseActivity<ActivitySetMateNicknameBinding>(R.l
                 name = ThreeDaysEvent.ButtonClicked.toString(),
                 properties = mapOf(
                     MixPanelEvent.ScreenName to "${Screen.MateMaking}3",
-                    MixPanelEvent.ButtonType to ButtonType.Next,
+                    MixPanelEvent.ButtonType to ButtonType.Next.toString(),
                 )
             )
             viewModel.createMate()

--- a/presentation/mate/src/main/java/com/depromeet/threedays/mate/share/ShareMateActivity.kt
+++ b/presentation/mate/src/main/java/com/depromeet/threedays/mate/share/ShareMateActivity.kt
@@ -19,8 +19,8 @@ import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import com.depromeet.threedays.core.BaseActivity
 import com.depromeet.threedays.core.analytics.*
-import com.depromeet.threedays.core.util.setOnSingleClickListener
 import com.depromeet.threedays.core.util.ThreeDaysToast
+import com.depromeet.threedays.core.util.setOnSingleClickListener
 import com.depromeet.threedays.mate.R
 import com.depromeet.threedays.mate.create.step1.model.toMateUI
 import com.depromeet.threedays.mate.databinding.ActivityShareMateBinding
@@ -48,8 +48,8 @@ class ShareMateActivity : BaseActivity<ActivityShareMateBinding>(R.layout.activi
             AnalyticsUtil.event(
                 name = ThreeDaysEvent.ButtonClicked.toString(),
                 properties = mapOf(
-                    MixPanelEvent.ScreenName to Screen.MateShare,
-                    MixPanelEvent.ButtonType to ButtonType.Close,
+                    MixPanelEvent.ScreenName to Screen.MateShare.toString(),
+                    MixPanelEvent.ButtonType to ButtonType.Close.toString(),
                 )
             )
 
@@ -59,8 +59,8 @@ class ShareMateActivity : BaseActivity<ActivityShareMateBinding>(R.layout.activi
             AnalyticsUtil.event(
                 name = ThreeDaysEvent.SharedPathClicked.toString(),
                 properties = mapOf(
-                    MixPanelEvent.ScreenName to Screen.MateShare,
-                    MixPanelEvent.ButtonType to ButtonType.SaveImg,
+                    MixPanelEvent.ScreenName to Screen.MateShare.toString(),
+                    MixPanelEvent.ButtonType to ButtonType.SaveImg.toString(),
                 )
             )
 
@@ -70,8 +70,8 @@ class ShareMateActivity : BaseActivity<ActivityShareMateBinding>(R.layout.activi
             AnalyticsUtil.event(
                 name = ThreeDaysEvent.SharedPathClicked.toString(),
                 properties = mapOf(
-                    MixPanelEvent.ScreenName to Screen.MateShare,
-                    MixPanelEvent.ButtonType to ButtonType.Insta,
+                    MixPanelEvent.ScreenName to Screen.MateShare.toString(),
+                    MixPanelEvent.ButtonType to ButtonType.Insta.toString(),
                 )
             )
 

--- a/presentation/signup/src/main/java/com/depromeet/threedays/signup/complete/SignupCompleteActivity.kt
+++ b/presentation/signup/src/main/java/com/depromeet/threedays/signup/complete/SignupCompleteActivity.kt
@@ -3,6 +3,7 @@ package com.depromeet.threedays.signup.complete
 import android.os.Bundle
 import androidx.activity.viewModels
 import com.depromeet.threedays.core.BaseActivity
+import com.depromeet.threedays.core.analytics.*
 import com.depromeet.threedays.core.util.setOnSingleClickListener
 import com.depromeet.threedays.navigator.HomeNavigator
 import com.depromeet.threedays.signup.R
@@ -19,12 +20,26 @@ class SignupCompleteActivity : BaseActivity<ActivitySignupCompleteBinding>(R.lay
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        AnalyticsUtil.event(
+            name = getViewedEventName(this),
+            properties = mapOf(
+                MixPanelEvent.ScreenName to getScreenName(this)
+            )
+        )
         viewModel.updateFcmToken()
         initView()
     }
 
     private fun initView() {
         binding.tvCheck.setOnSingleClickListener {
+            AnalyticsUtil.event(
+                name = ThreeDaysEvent.ButtonClicked.toString(),
+                properties = mapOf(
+                    MixPanelEvent.ScreenName to getScreenName(this),
+                    MixPanelEvent.ButtonType to ButtonType.Next.toString()
+                )
+            )
+
             val intent = homeNavigator.intent(this)
             startActivity(intent)
             finish()


### PR DESCRIPTION
## 💁‍♂️ 변경 내용
### AS-IS
- 몇몇 값이 null로 갔습니다.
- 푸시유도 바텀시트, 회원가입 완료화면에 이벤트가 없었습니다.

### TO-BE
- 이벤트 값이 null로 가는 현상을 해결했습니다.
- 박수 완료 모달 제외, 이벤트를 붙였습니다.

## 📢 전달사항
- null로 갔던 이유가, 지금 저희가 `enum class`를 통해 이벤트 프로퍼티 값을 넣었는데, Json object로 변경하면서 문제가 생겼던 것 같습니다.. 위 문제는 추후 천천히 해결해보고 지금은 노가다(?)로 해결해놓았습니다...(`toString()`)