### PR TITLE
DEP-000 fix: 로그아웃, 회원탈퇴시 앱에 저장된 데이터 모두 삭제

### DIFF
--- a/data/src/main/java/com/depromeet/threedays/data/di/RepositoryModule.kt
+++ b/data/src/main/java/com/depromeet/threedays/data/di/RepositoryModule.kt
@@ -89,4 +89,10 @@ abstract class RepositoryModule {
     abstract fun bindsDeviceUniqueIdRepository(
         repository: DeviceUniqueIdRepositoryImpl,
     ): DeviceUniqueIdRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindsLocalDataRepository(
+        repository: LocalDataRepositoryImpl,
+    ): LocalDataRepository
 }

--- a/data/src/main/java/com/depromeet/threedays/data/repository/LocalDataRepositoryImpl.kt
+++ b/data/src/main/java/com/depromeet/threedays/data/repository/LocalDataRepositoryImpl.kt
@@ -1,0 +1,13 @@
+package com.depromeet.threedays.data.repository
+
+import com.depromeet.threedays.data.datasource.datastore.DataStoreDataSource
+import com.depromeet.threedays.domain.repository.LocalDataRepository
+import javax.inject.Inject
+
+class LocalDataRepositoryImpl @Inject constructor(
+    private val dataStoreDataSource: DataStoreDataSource,
+) : LocalDataRepository {
+    override suspend fun removeAll() {
+        dataStoreDataSource.resetDataStore()
+    }
+}

--- a/domain/src/main/java/com/depromeet/threedays/domain/repository/LocalDataRepository.kt
+++ b/domain/src/main/java/com/depromeet/threedays/domain/repository/LocalDataRepository.kt
@@ -1,0 +1,5 @@
+package com.depromeet.threedays.domain.repository
+
+interface LocalDataRepository {
+    suspend fun removeAll()
+}

--- a/domain/src/main/java/com/depromeet/threedays/domain/usecase/member/LogoutUseCase.kt
+++ b/domain/src/main/java/com/depromeet/threedays/domain/usecase/member/LogoutUseCase.kt
@@ -1,17 +1,19 @@
 package com.depromeet.threedays.domain.usecase.member
 
 import com.depromeet.threedays.domain.repository.AuthRepository
+import com.depromeet.threedays.domain.repository.DeviceUniqueIdRepository
 import com.depromeet.threedays.domain.repository.MemberRepository
 import javax.inject.Inject
 
 class LogoutUseCase @Inject constructor(
     private val memberRepository: MemberRepository,
+    private val deviceUniqueIdRepository: DeviceUniqueIdRepository,
     private val authRepository: AuthRepository,
 ) {
     suspend operator fun invoke() {
-        // TODO: deviceId 조회 기능 추가
-        val deviceId = "identificationKey"
-        memberRepository.logout(deviceId = deviceId)
+        deviceUniqueIdRepository.findOne()?.let { deviceId ->
+            memberRepository.logout(deviceId = deviceId)
+        }
         authRepository.removeTokensFromLocal()
         // TODO: notification permission 삭제
     }

--- a/domain/src/main/java/com/depromeet/threedays/domain/usecase/member/LogoutUseCase.kt
+++ b/domain/src/main/java/com/depromeet/threedays/domain/usecase/member/LogoutUseCase.kt
@@ -2,6 +2,7 @@ package com.depromeet.threedays.domain.usecase.member
 
 import com.depromeet.threedays.domain.repository.AuthRepository
 import com.depromeet.threedays.domain.repository.DeviceUniqueIdRepository
+import com.depromeet.threedays.domain.repository.LocalDataRepository
 import com.depromeet.threedays.domain.repository.MemberRepository
 import javax.inject.Inject
 
@@ -9,12 +10,13 @@ class LogoutUseCase @Inject constructor(
     private val memberRepository: MemberRepository,
     private val deviceUniqueIdRepository: DeviceUniqueIdRepository,
     private val authRepository: AuthRepository,
+    private val localDataRepository: LocalDataRepository,
 ) {
     suspend operator fun invoke() {
         deviceUniqueIdRepository.findOne()?.let { deviceId ->
             memberRepository.logout(deviceId = deviceId)
         }
         authRepository.removeTokensFromLocal()
-        // TODO: notification permission 삭제
+        localDataRepository.removeAll()
     }
 }

--- a/domain/src/main/java/com/depromeet/threedays/domain/usecase/member/WithdrawUseCase.kt
+++ b/domain/src/main/java/com/depromeet/threedays/domain/usecase/member/WithdrawUseCase.kt
@@ -1,16 +1,18 @@
 package com.depromeet.threedays.domain.usecase.member
 
 import com.depromeet.threedays.domain.repository.AuthRepository
+import com.depromeet.threedays.domain.repository.LocalDataRepository
 import com.depromeet.threedays.domain.repository.MemberRepository
 import javax.inject.Inject
 
 class WithdrawUseCase @Inject constructor(
     private val memberRepository: MemberRepository,
     private val authRepository: AuthRepository,
+    private val localDataRepository: LocalDataRepository,
 ) {
     suspend operator fun invoke() {
         memberRepository.withdraw()
         authRepository.removeTokensFromLocal()
-        // TODO: notification permission 삭제
+        localDataRepository.removeAll()
     }
 }


### PR DESCRIPTION
## 💁‍♂️ 변경 내용
### AS-IS
- deviceId 하드코딩된 값 사용
### TO-BE
- dataStore 에 저장된값 사용함
## 📢 전달사항
