### PR TITLE
feature: 습관과 짝꿍 유무에 따라 믹스패널을 보내주는 위치 변경

### DIFF
--- a/presentation/home/src/main/java/com/depromeet/threedays/home/home/HomeFragment.kt
+++ b/presentation/home/src/main/java/com/depromeet/threedays/home/home/HomeFragment.kt
@@ -60,9 +60,9 @@ class HomeFragment : BaseFragment<FragmentHomeBinding, HomeViewModel>(R.layout.f
     private val addResultLauncher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
 
         when(result.resultCode) {
-            RESULT_CREATE -> viewModel.fetchGoals()
+            RESULT_CREATE -> viewModel.fetchHabits()
             RESULT_UPDATE -> {
-                viewModel.fetchGoals()
+                viewModel.fetchHabits()
                 ThreeDaysToast().show(
                     requireContext(),
                     resources.getString(com.depromeet.threedays.core.R.string.toast_habit_modify_complete)
@@ -251,22 +251,6 @@ class HomeFragment : BaseFragment<FragmentHomeBinding, HomeViewModel>(R.layout.f
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 launch {
                     viewModel.habits.collect { list ->
-                        if (list.isEmpty()) {
-                            AnalyticsUtil.event(
-                                name = ThreeDaysEvent.HomeDefaultViewed.toString(),
-                                properties = mapOf(
-                                    MixPanelEvent.ScreenName to Screen.HomeDefault.toString()
-                                )
-                            )
-                        } else {
-                            AnalyticsUtil.event(
-                                name = ThreeDaysEvent.HomeActivatedViewed.toString(),
-                                properties = mapOf(
-                                    MixPanelEvent.ScreenName to Screen.HomeActivated.toString()
-                                )
-                            )
-                        }
-
                         habitAdapter.submitList(list.sortedBy { it.createAt })
                         binding.clNoGoal.visibility =
                             if (list.isEmpty()) View.VISIBLE else View.GONE

--- a/presentation/mate/src/main/java/com/depromeet/threedays/mate/MateFragment.kt
+++ b/presentation/mate/src/main/java/com/depromeet/threedays/mate/MateFragment.kt
@@ -209,7 +209,6 @@ class MateFragment: BaseFragment<FragmentMateBinding, MateViewModel>(R.layout.fr
                         if (it.isMateInitialized) {
                             if( (it.hasMate && it.isHabitInitialized) || !it.hasMate) {
                                 binding.progressMate.gone()
-                                sendEvent(it.hasMate)
                                 showMateOrDefaultView(
                                     hasMate = it.hasMate,
                                     backgroundResColor = it.backgroundResColor
@@ -339,24 +338,6 @@ class MateFragment: BaseFragment<FragmentMateBinding, MateViewModel>(R.layout.fr
         ).show(
             parentFragmentManager, ThreeDaysNoButtonDialogFragment.TAG
         )
-    }
-
-    private fun sendEvent(hasMate: Boolean) {
-        if(hasMate) {
-            AnalyticsUtil.event(
-                name = ThreeDaysEvent.MateHomeViewed.toString(),
-                properties = mapOf(
-                    MixPanelEvent.ScreenName to Screen.MateHome.toString(),
-                )
-            )
-        } else {
-            AnalyticsUtil.event(
-                name = ThreeDaysEvent.MateDefaultViewed.toString(),
-                properties = mapOf(
-                    MixPanelEvent.ScreenName to Screen.MateDefault.toString(),
-                )
-            )
-        }
     }
 
     override fun onStop() {

--- a/presentation/mate/src/main/java/com/depromeet/threedays/mate/MateViewModel.kt
+++ b/presentation/mate/src/main/java/com/depromeet/threedays/mate/MateViewModel.kt
@@ -2,6 +2,10 @@ package com.depromeet.threedays.mate
 
 import androidx.lifecycle.viewModelScope
 import com.depromeet.threedays.core.BaseViewModel
+import com.depromeet.threedays.core.analytics.AnalyticsUtil
+import com.depromeet.threedays.core.analytics.MixPanelEvent
+import com.depromeet.threedays.core.analytics.Screen
+import com.depromeet.threedays.core.analytics.ThreeDaysEvent
 import com.depromeet.threedays.domain.entity.Color
 import com.depromeet.threedays.domain.entity.OnboardingType
 import com.depromeet.threedays.domain.entity.Status
@@ -58,7 +62,7 @@ class MateViewModel @Inject constructor(
                         val myMate = response.data!!.find { it.status == "ACTIVE" }
                         _uiState.update {
                             it.copy(
-                                mate = myMate?.toMateUI() ,
+                                mate = myMate?.toMateUI(),
                                 hasMate = myMate != null,
                                 backgroundResColor = if(myMate == null) {
                                     core_design.color.white
@@ -72,6 +76,22 @@ class MateViewModel @Inject constructor(
                             fetchHabit(it.habitId)
                         }
                         checkMateAchieveMaxLevel(uiState.value.mate)
+
+                        if (myMate == null) {
+                            AnalyticsUtil.event(
+                                name = ThreeDaysEvent.MateDefaultViewed.toString(),
+                                properties = mapOf(
+                                    MixPanelEvent.ScreenName to Screen.MateDefault.toString(),
+                                )
+                            )
+                        } else {
+                            AnalyticsUtil.event(
+                                name = ThreeDaysEvent.MateHomeViewed.toString(),
+                                properties = mapOf(
+                                    MixPanelEvent.ScreenName to Screen.MateHome.toString(),
+                                )
+                            )
+                        }
                     }
                     Status.ERROR -> {
 


### PR DESCRIPTION
## 💁‍♂️ 변경 내용
### AS-IS
- collect 하는 부분에서 믹스패널 이벤트를 날려 리스트에 변화가 있을 때마다 중복된 이벤트가 발생했습니다.

### TO-BE
- viewModel에서 response를 받는 부분에서 바로 직접 이벤트를 날립니다.

## 📢 전달사항
fetchGoals -> fetchHabits로 네이밍 변경 (눈에 보이길래 그냥 같이 수정했습니다)