### PR TITLE
DEP-400 ui: 다크모드 지원하지 않도록 수정

### DIFF
--- a/core-design-system/src/main/res/values-night/themes.xml
+++ b/core-design-system/src/main/res/values-night/themes.xml
@@ -1,6 +1,6 @@
 <resources>
     <!-- Base application theme. -->
-    <style name="Theme.ThreeDays" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
+    <style name="Theme.ThreeDays" parent="Theme.MaterialComponents.Light.NoActionBar">
         <!-- Primary brand color. -->
         <item name="colorPrimary">@color/primary</item>
         <item name="colorPrimaryVariant">@color/press</item>


### PR DESCRIPTION
## 💁‍♂️ 변경 내용
### AS-IS
- 다크모드로 앱에 접속하면 흰색이 검은색으로 보이고 action bar도 그대로 보였습니다.

### TO-BE
- 다크모드를 지원하지 않게 하였습니다. (= 다크모드 선택 시 라이트모드처럼 보이게 함. 다크모드에서 action bar 없앰)