### PR TITLE
DEP-409 ui: 다크모드 적용되지 않았던 부분 적용 in 홈/생성&수정화면

### DIFF
--- a/core-design-system/src/main/res/drawable/ic_check.xml
+++ b/core-design-system/src/main/res/drawable/ic_check.xml
@@ -5,5 +5,5 @@
     android:viewportHeight="11">
   <path
       android:pathData="M6.6,10.2C6.3,10.2 6,10.1 5.8,9.8L1.2,5.2C0.7,4.7 0.7,4 1.2,3.5C1.7,3 2.4,3 2.9,3.5L6.6,7.2L13.2,0.6C13.7,0.1 14.4,0.1 14.9,0.6C15.4,1.1 15.4,1.8 14.9,2.3L7.5,9.7C7.2,10.1 6.9,10.2 6.6,10.2Z"
-      android:fillColor="#FFFFFF"/>
+      android:fillColor="@color/check_icon"/>
 </vector>

--- a/core-design-system/src/main/res/values-night/colors.xml
+++ b/core-design-system/src/main/res/values-night/colors.xml
@@ -21,7 +21,7 @@
     <color name="white">#17171B</color>
     <color name="gray_background">#F6F7F9</color>
     <color name="gray_100">#2C2C34</color>
-    <color name="gray_200">#3D3D58</color>
+    <color name="gray_200">#4D4D58</color>
     <color name="gray_300">#62626C</color>
     <color name="gray_400">#7E7E86</color>
     <color name="gray_450">#7E7E86</color>

--- a/core-design-system/src/main/res/values-night/colors.xml
+++ b/core-design-system/src/main/res/values-night/colors.xml
@@ -43,5 +43,6 @@
     <color name="add_icon_background">#3D3D58</color>
     <color name="add_icon_plus">#E4E4E5</color>
     <color name="noti_icon">#7E7E86</color>
+    <color name="check_icon">#17171A</color>
 
 </resources>

--- a/core-design-system/src/main/res/values/colors.xml
+++ b/core-design-system/src/main/res/values/colors.xml
@@ -43,5 +43,6 @@
     <color name="add_icon_background">#D8DCE2</color>
     <color name="add_icon_plus">#8E95A3</color>
     <color name="noti_icon">#8E95A3</color>
+    <color name="check_icon">#FFFFFF</color>
 
 </resources>

--- a/presentation/home/src/main/res/layout/modal_more_action.xml
+++ b/presentation/home/src/main/res/layout/modal_more_action.xml
@@ -25,28 +25,29 @@
                 android:layout_width="24dp"
                 android:layout_height="24dp"
                 android:layout_margin="16dp"
-                android:src="@drawable/ic_edit"
-                app:layout_constraintTop_toTopOf="parent"
-                app:layout_constraintStart_toStartOf="parent"/>
+                android:background="@drawable/ic_edit"
+                android:backgroundTint="@color/gray_700"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
 
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="@string/edit"
-                android:textColor="@color/gray_700"
-                android:textAppearance="@style/Typography.Body1"
                 android:layout_marginStart="8dp"
+                android:text="@string/edit"
+                android:textAppearance="@style/Typography.Body1"
+                android:textColor="@color/gray_700"
+                app:layout_constraintBottom_toBottomOf="@+id/iv_edit"
                 app:layout_constraintStart_toEndOf="@+id/iv_edit"
-                app:layout_constraintTop_toTopOf="@+id/iv_edit"
-                app:layout_constraintBottom_toBottomOf="@+id/iv_edit" />
+                app:layout_constraintTop_toTopOf="@+id/iv_edit" />
         </androidx.constraintlayout.widget.ConstraintLayout>
 
         <View
             android:layout_width="match_parent"
             android:layout_height="1dp"
-            android:background="@color/gray_100"
-            android:layout_margin="16dp"/>
-        
+            android:layout_margin="16dp"
+            android:background="@color/gray_100" />
+
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/cl_delete"
             android:layout_width="match_parent"
@@ -59,20 +60,20 @@
                 android:layout_marginStart="16dp"
                 android:background="@drawable/ic_delete"
                 android:backgroundTint="@color/gray_700"
-                app:layout_constraintTop_toTopOf="parent"
-                app:layout_constraintStart_toStartOf="parent"/>
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
 
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="@string/delete"
-                android:textColor="@color/gray_700"
-                android:textAppearance="@style/Typography.Body1"
                 android:layout_gravity="center"
                 android:layout_marginStart="8dp"
-                app:layout_constraintTop_toTopOf="@id/iv_delete"
+                android:text="@string/delete"
+                android:textAppearance="@style/Typography.Body1"
+                android:textColor="@color/gray_700"
+                app:layout_constraintBottom_toBottomOf="@id/iv_delete"
                 app:layout_constraintStart_toEndOf="@+id/iv_delete"
-                app:layout_constraintBottom_toBottomOf="@id/iv_delete"/>
+                app:layout_constraintTop_toTopOf="@id/iv_delete" />
         </androidx.constraintlayout.widget.ConstraintLayout>
 
         <Space


### PR DESCRIPTION
## 💁‍♂️ 변경 내용
### AS-IS
- 생성/수정 화면의 체크 아이콘에 다크모드가 적용되지 않았습니다.
- 다크모드의 gray 200값이 피그마의 값과 달랐습니다.
- 홈화면의 습관 더보기에서 수정하기 아이콘에 다크모드가 적용되지 않았습니다.

### TO-BE
- 생성/수정 화면의 체크아이콘에 다크모드가 적용되었습니다.
- 다크모드의 gray 200값을 피그마의 값으로 수정했습니다.
- 홈화면의 습관 더보기에서 수정하기 아이콘에 다크모드가 적용되었습니다.

## 📢 전달사항
