### PR TITLE
DEP-420 feat: sentry 도입

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -41,20 +41,24 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
             manifestPlaceholders = [
-                    KAKAO_APP_KEY: properties.getProperty('release.kakao.app-key')
+                    KAKAO_APP_KEY: properties.getProperty('release.kakao.app-key'),
+                    SENTRY_DSN: properties.getProperty('release.sentry.dsn')
             ]
             buildConfigField 'String', 'BASE_URL', "\"${properties.getProperty('release.three-days.base-url')}\""
             buildConfigField 'String', 'KAKAO_APP_KEY', "\"${properties.getProperty('release.kakao.app-key')}\""
             buildConfigField 'String', 'MIXPANEL_PROJECT_TOKEN', "\"${properties.getProperty('release.mixpanel.project-token')}\""
+            buildConfigField 'String', 'SENTRY_DSN', "\"${properties.getProperty('release.sentry.dsn')}\""
         }
         debug {
             applicationIdSuffix '.debug'
             manifestPlaceholders = [
-                    KAKAO_APP_KEY: properties.getProperty('debug.kakao.app-key')
+                    KAKAO_APP_KEY: properties.getProperty('debug.kakao.app-key'),
+                    SENTRY_DSN: properties.getProperty('debug.sentry.dsn')
             ]
             buildConfigField 'String', 'BASE_URL', "\"${properties.getProperty('debug.three-days.base-url')}\""
             buildConfigField 'String', 'KAKAO_APP_KEY', "\"${properties.getProperty('debug.kakao.app-key')}\""
             buildConfigField 'String', 'MIXPANEL_PROJECT_TOKEN', "\"${properties.getProperty('debug.mixpanel.project-token')}\""
+            buildConfigField 'String', 'SENTRY_DSN', "\"${properties.getProperty('debug.sentry.dsn')}\""
         }
         alpha {
             initWith debug

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -62,35 +62,42 @@
             android:name="com.depromeet.threedays.mypage.archived_habit.ArchivedHabitActivity"
             android:exported="false" />
 
-        <activity android:name=".mate.create.step1.ConnectHabitActivity"
+        <activity
+            android:name=".mate.create.step1.ConnectHabitActivity"
             android:exported="false"
             android:taskAffinity="com.depromeet.threedays.mate"
             android:theme="@style/WhiteStatusTheme" />
 
-        <activity android:name=".mate.create.step2.ChooseMateTypeActivity"
+        <activity
+            android:name=".mate.create.step2.ChooseMateTypeActivity"
             android:exported="false"
             android:taskAffinity="com.depromeet.threedays.mate"
             android:theme="@style/WhiteStatusTheme" />
 
-        <activity android:name=".mate.create.step3.SetMateNicknameActivity"
+        <activity
+            android:name=".mate.create.step3.SetMateNicknameActivity"
             android:exported="false"
             android:taskAffinity="com.depromeet.threedays.mate"
             android:theme="@style/WhiteStatusTheme" />
 
-        <activity android:name="com.depromeet.threedays.policy.PolicyActivity"
+        <activity
+            android:name="com.depromeet.threedays.policy.PolicyActivity"
             android:exported="false" />
 
-        <activity android:name=".signup.SignupActivity"
-            android:exported="true"/>
+        <activity
+            android:name=".signup.SignupActivity"
+            android:exported="true" />
 
-        <activity android:name=".signup.complete.SignupCompleteActivity"
-            android:exported="false"/>
+        <activity
+            android:name=".signup.complete.SignupCompleteActivity"
+            android:exported="false" />
 
         <activity
             android:name="com.kakao.sdk.auth.AuthCodeHandlerActivity"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
+
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
 
@@ -108,6 +115,31 @@
                 <action android:name="com.google.firebase.MESSAGING_EVENT" />
             </intent-filter>
         </service>
+
+        <!-- Required: set your sentry.io project identifier (DSN) -->
+        <meta-data
+            android:name="io.sentry.dsn"
+            android:value="${SENTRY_DSN}" />
+        <!-- enable automatic breadcrumbs for user interactions (clicks, swipes, scrolls) -->
+        <meta-data
+            android:name="io.sentry.traces.user-interaction.enable"
+            android:value="true" />
+        <!-- enable screenshot for crashes -->
+        <meta-data
+            android:name="io.sentry.attach-screenshot"
+            android:value="true" />
+        <!-- enable view hierarchy for crashes -->
+        <meta-data
+            android:name="io.sentry.attach-view-hierarchy"
+            android:value="true" />
+        <!-- enable the performance API by setting a sample-rate, adjust in production env -->
+        <meta-data
+            android:name="io.sentry.traces.sample-rate"
+            android:value="1.0" />
+        <!-- enable profiling when starting transactions, adjust in production env -->
+        <meta-data
+            android:name="io.sentry.traces.profiling.sample-rate"
+            android:value="1.0" />
 
     </application>
 

--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ plugins {
     id 'org.jetbrains.kotlin.android' version '1.6.10' apply false
     id "org.sonarqube" version "3.4.0.2513"
     id 'org.jetbrains.kotlin.jvm' version '1.6.10' apply false
+    id 'io.sentry.android.gradle' version "3.12.0"
 }
 
 task clean(type: Delete) {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -43,6 +43,7 @@ android {
 dependencies {
     implementation(project(":core-design-system"))
     implementation(project(":build-property"))
+    implementation(project(":domain"))
 
     implementation(jetpackDeps)
     implementation(coroutines)
@@ -54,6 +55,8 @@ dependencies {
     implementation deps.timber
 
     implementation deps.mixpanel
+
+    implementation deps.sentry
 
     testImplementation(testDeps)
     androidTestImplementation(androidTestDeps)

--- a/core/src/main/java/com/depromeet/threedays/core/BaseViewModel.kt
+++ b/core/src/main/java/com/depromeet/threedays/core/BaseViewModel.kt
@@ -2,6 +2,7 @@ package com.depromeet.threedays.core
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.depromeet.threedays.domain.exception.ThreeDaysException
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -14,8 +15,8 @@ abstract class BaseViewModel : ViewModel() {
     val loading: StateFlow<Boolean>
         get() = _loading
 
-    private val _error = MutableSharedFlow<String>()
-    val error: SharedFlow<String>
+    private val _error = MutableSharedFlow<ThreeDaysException>()
+    val error: SharedFlow<ThreeDaysException>
         get() = _error
 
     protected fun startLoading() {
@@ -26,13 +27,13 @@ abstract class BaseViewModel : ViewModel() {
         _loading.value = false
     }
 
-    protected fun sendErrorMessage(throwable: Throwable) {
-        sendErrorMessage(throwable.message)
-    }
+    protected fun sendError(throwable: ThreeDaysException) {
+        if (throwable.message.equals(ThreeDaysException.UNKNOWN_EXCEPTION)) {
+            throwable.message = throwable.defaultMessage
+        }
 
-    protected fun sendErrorMessage(message: String?) {
         viewModelScope.launch {
-            _error.emit(message ?: "알 수 없는 오류가 발생했어요.")
+            _error.emit(throwable)
         }
     }
 }

--- a/core/src/main/java/com/depromeet/threedays/core/util/ThreeDaysToast.kt
+++ b/core/src/main/java/com/depromeet/threedays/core/util/ThreeDaysToast.kt
@@ -26,19 +26,17 @@ class ThreeDaysToast {
 
     fun error(
         context: Context,
-        title: String?,
+        title: String,
         duration: Int = Toast.LENGTH_SHORT
     ) {
-        if(title != null) {
-            val inflater = LayoutInflater.from(context)
-            val toast = Toast(context)
-            val view = inflater.inflate(R.layout.error_toast_three_days, null)
-            val textView: TextView = view.findViewById(R.id.tv_toast)
-            textView.text = title
-            toast.setGravity(Gravity.BOTTOM or Gravity.FILL_HORIZONTAL, 0, 0)
-            toast.view = view
-            toast.duration = duration
-            toast.show()
-        }
+        val inflater = LayoutInflater.from(context)
+        val toast = Toast(context)
+        val view = inflater.inflate(R.layout.error_toast_three_days, null)
+        val textView: TextView = view.findViewById(R.id.tv_toast)
+        textView.text = title
+        toast.setGravity(Gravity.BOTTOM or Gravity.FILL_HORIZONTAL, 0, 0)
+        toast.view = view
+        toast.duration = duration
+        toast.show()
     }
 }

--- a/data/src/main/java/com/depromeet/threedays/data/api/exception/ResultCall.kt
+++ b/data/src/main/java/com/depromeet/threedays/data/api/exception/ResultCall.kt
@@ -18,7 +18,7 @@ class ResultCall<T>(private val call: Call<T>, private val retrofit: Retrofit) :
                     if(response.body() == null) {
                         callback.onResponse(
                             this@ResultCall,
-                            Response.success(Result.failure(ThreeDaysException("body가 비었습니다.", HttpException(response))))
+                            Response.success(Result.failure(ThreeDaysException(ThreeDaysException.NO_BODY_RESPONSE, HttpException(response))))
                         )
                     }
                     else {
@@ -32,7 +32,7 @@ class ResultCall<T>(private val call: Call<T>, private val retrofit: Retrofit) :
 
                     if(response.errorBody() == null) {
                         callback.onResponse( this@ResultCall,
-                            Response.success(Result.failure(ThreeDaysException("errorBody가 비었습니다.", HttpException(response))))
+                            Response.success(Result.failure(ThreeDaysException(ThreeDaysException.NO_ERROR_BODY_RESPONSE, HttpException(response))))
                         )
                     }
                     else {
@@ -41,7 +41,7 @@ class ResultCall<T>(private val call: Call<T>, private val retrofit: Retrofit) :
                             ErrorResponse::class.java.annotations
                         ).convert(response.errorBody()!!)
 
-                        val message: String = errorBody?.message ?: "errorBody가 비었습니다"
+                        val message: String = errorBody?.message ?: ThreeDaysException.NO_ERROR_MESSAGE_RESPONSE
 
                         callback.onResponse(this@ResultCall,
                             Response.success(Result.failure(ThreeDaysException(message, HttpException(response))))
@@ -55,8 +55,8 @@ class ResultCall<T>(private val call: Call<T>, private val retrofit: Retrofit) :
 
             override fun onFailure(call: Call<T>, t: Throwable) {
                 val message = when (t) {
-                    is IOException -> "인터넷 연결이 끊겼습니다."
-                    is HttpException -> "알 수 없는 오류가 발생했어요."
+                    is IOException -> ThreeDaysException.INTERNET_CONNECTION_WAS_LOST
+                    is HttpException -> ThreeDaysException.UNKNOWN_EXCEPTION
                     else -> t.localizedMessage
                 }
                 callback.onResponse(

--- a/data/src/main/java/com/depromeet/threedays/data/entity/base/ApiResponse.kt
+++ b/data/src/main/java/com/depromeet/threedays/data/entity/base/ApiResponse.kt
@@ -1,5 +1,7 @@
 package com.depromeet.threedays.data.entity.base
 
+import com.depromeet.threedays.domain.exception.ThreeDaysException
+
 data class ApiResponse<T>(
     val data: T?,
     val message: String,
@@ -13,5 +15,5 @@ fun <T>Result<ApiResponse<T>>.getResult(): Result<T>? {
     }.onFailure { throwable ->
         return Result.failure(throwable)
     }
-    return Result.failure(IllegalStateException("알 수 없는 오류가 발생했습니다."))
+    return Result.failure(IllegalStateException(ThreeDaysException.UNKNOWN_EXCEPTION))
 }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -30,7 +30,8 @@ ext {
             "lottie"                : "5.2.0",
             "datastore"             : "1.0.0",
             "ossLicenses"           : "17.0.0",
-            "mixpanel"             : "7.+",
+            "mixpanel"              : "7.+",
+            "sentry"                : "6.28.0",
     ]
     deps = [
             "kotlin"          : [
@@ -113,6 +114,7 @@ ext {
             "splash"                       : "androidx.core:core-splashscreen:1.0.0",
             "ossLicenses"                  : "com.google.android.gms:play-services-oss-licenses:${versions.ossLicenses}",
             "mixpanel"                     : "com.mixpanel.android:mixpanel-android:${versions.mixpanel}",
+            "sentry"                       : "io.sentry:sentry-android:${versions.sentry}"
     ]
 
     coroutines = [

--- a/domain/src/main/java/com/depromeet/threedays/domain/exception/ThreeDaysException.kt
+++ b/domain/src/main/java/com/depromeet/threedays/domain/exception/ThreeDaysException.kt
@@ -1,17 +1,15 @@
 package com.depromeet.threedays.domain.exception
 
-class ThreeDaysException(override val message: String, throwable: Throwable) : Exception(message, throwable) {
-//    override val message: String? = when(code) {
-//        HABIT_CONSTRAINTS_INSUFFICIENT_DAY_OF_WEEKS -> "실천 요일을 3개 이상 선택해 주세요."
-//        HABIT_ACHIEVEMENT_CONSTRAINTS_DATE_IS_IN_THE_PAST -> "이전의 기록을 변경할 수 없어요."
-//        HABIT_ACHIEVEMENT_CONSTRAINTS_INVALID_ACHIEVEMENT_DATE -> "습관 취소는 오늘만 할 수 있어요"
-//        HABIT_CONSTRAINTS_INSUFFICIENT_NOTIFICATION -> "Push 알림을 마저 설정해 주세요."
-//        MEMBER_CONSTRAINTS_INVALID_MEMBER -> "가입된 기록이 없어요."
-//        MEMBER_NOT_FOUND -> "가입된 기록이 없어요."
-//        SOCIAL_LOGIN_ERROR -> "로그인에 실패했어요."
-//        MATE_CONSTRAINTS_ALREADY_EXIST_MATE -> "이미 함께하고 있는 짝꿍이 있어요."
-//        METHOD_ARGUMENT_NOT_VALID_EXCEPTION_BIND_EXCEPTION, BAD_REQUEST, UNKNOWN_ERROR -> "알 수 없는 오류가 발생했어요."
-//        NO_INTERNET_CONNECTION -> "인터넷 연결이 끊겼습니다."
-//        else -> null
-//    }
+class ThreeDaysException(override var message: String?, throwable: Throwable) : Exception(message, throwable) {
+    var defaultMessage = UNKNOWN_EXCEPTION
+    companion object {
+        const val UNKNOWN_EXCEPTION = "알 수 없는 오류가 발생했어요."
+        const val INTERNET_CONNECTION_WAS_LOST = "인터넷 연결이 끊겼습니다."
+        const val NO_BODY_RESPONSE = "응답이 비었습니다."
+        const val NO_ERROR_BODY_RESPONSE = "에러 응답이 비었습니다."
+        const val NO_ERROR_MESSAGE_RESPONSE = "에러 메세지가 비었습니다."
+        const val LOGIN_FAIL = "로그인에 실패하였습니다. 잠시 후 다시 시도해주세요."
+        const val LOGOUT_FAIL = "로그아웃에 실패했습니다. 잠시 후 다시 시도해주세요."
+        const val MEMBERSHIP_WITHDRAWAL_FAIL = "회원탈퇴를 실패했습니다. 잠시 후 다시 시도해주세요."
+    }
 }

--- a/presentation/create/build.gradle
+++ b/presentation/create/build.gradle
@@ -53,6 +53,8 @@ dependencies {
 
     implementation deps.timber
 
+    implementation deps.sentry
+
     testImplementation(testDeps)
     androidTestImplementation(androidTestDeps)
 }

--- a/presentation/create/src/main/java/com/depromeet/threedays/create/create/HabitCreateViewModel.kt
+++ b/presentation/create/src/main/java/com/depromeet/threedays/create/create/HabitCreateViewModel.kt
@@ -135,7 +135,7 @@ class HabitCreateViewModel @Inject constructor(
                     _action.emit(Action.SaveClick)
                 }.onFailure { throwable ->
                     throwable as ThreeDaysException
-                    sendErrorMessage(throwable.message)
+                    sendError(throwable)
                 }
         }
     }

--- a/presentation/create/src/main/java/com/depromeet/threedays/create/update/HabitUpdateActivity.kt
+++ b/presentation/create/src/main/java/com/depromeet/threedays/create/update/HabitUpdateActivity.kt
@@ -19,9 +19,11 @@ import com.depromeet.threedays.create.databinding.ActivityHabitUpdateBinding
 import com.depromeet.threedays.create.emoji.EmojiBottomSheetDialogFragment
 import com.depromeet.threedays.create.update.HabitUpdateViewModel.Action
 import com.depromeet.threedays.domain.entity.Color
+import com.depromeet.threedays.domain.exception.ThreeDaysException
 import com.depromeet.threedays.domain.key.HABIT_ID
 import com.depromeet.threedays.domain.key.RESULT_UPDATE
 import dagger.hilt.android.AndroidEntryPoint
+import io.sentry.Sentry
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import java.time.DayOfWeek
@@ -156,21 +158,27 @@ class HabitUpdateActivity :
                         DayOfWeek.MONDAY -> {
                             binding.cbMonday.isChecked = true
                         }
+
                         DayOfWeek.TUESDAY -> {
                             binding.cbTuesday.isChecked = true
                         }
+
                         DayOfWeek.WEDNESDAY -> {
                             binding.cbWednesday.isChecked = true
                         }
+
                         DayOfWeek.THURSDAY -> {
                             binding.cbThursday.isChecked = true
                         }
+
                         DayOfWeek.FRIDAY -> {
                             binding.cbFriday.isChecked = true
                         }
+
                         DayOfWeek.SATURDAY -> {
                             binding.cbSaturday.isChecked = true
                         }
+
                         DayOfWeek.SUNDAY -> {
                             binding.cbSunday.isChecked = true
                         }
@@ -203,6 +211,7 @@ class HabitUpdateActivity :
                         setResult(RESULT_UPDATE)
                         finish()
                     }
+
                     is Action.NotificationTimeClick -> {
                         showTimePicker(action.currentTime)
                     }
@@ -210,7 +219,12 @@ class HabitUpdateActivity :
             }.launchIn(lifecycleScope)
 
         viewModel.error
-            .onEach { errorMessage -> ThreeDaysToast().error(this, errorMessage) }
+            .onEach { error ->
+                ThreeDaysToast().error(this, error.message ?: error.defaultMessage)
+                if (error.message != ThreeDaysException.INTERNET_CONNECTION_WAS_LOST) {
+                    Sentry.captureException(error)
+                }
+            }
             .launchIn(lifecycleScope)
     }
 

--- a/presentation/create/src/main/java/com/depromeet/threedays/create/update/HabitUpdateViewModel.kt
+++ b/presentation/create/src/main/java/com/depromeet/threedays/create/update/HabitUpdateViewModel.kt
@@ -87,7 +87,7 @@ class HabitUpdateViewModel @Inject constructor(
                     setOldData(habit)
                 }.onFailure { throwable ->
                     throwable as ThreeDaysException
-                    sendErrorMessage(throwable.message)
+                    sendError(throwable)
                 }
         }
    }
@@ -194,7 +194,7 @@ class HabitUpdateViewModel @Inject constructor(
                     _action.emit(Action.UpdateClick)
                 }.onFailure { throwable ->
                     throwable as ThreeDaysException
-                    sendErrorMessage(throwable.message)
+                    sendError(throwable)
                 }
         }
     }

--- a/presentation/history/build.gradle
+++ b/presentation/history/build.gradle
@@ -55,6 +55,8 @@ dependencies {
 
     implementation deps.timber
 
+    implementation deps.sentry
+
     testImplementation(testDeps)
     androidTestImplementation(androidTestDeps)
 }

--- a/presentation/history/src/main/java/com/depromeet/threedays/history/HistoryViewModel.kt
+++ b/presentation/history/src/main/java/com/depromeet/threedays/history/HistoryViewModel.kt
@@ -61,7 +61,7 @@ class HistoryViewModel @Inject constructor(
                     }
                 }.onFailure { throwable ->
                     throwable as ThreeDaysException
-                    sendErrorMessage(throwable.message)
+                    sendError(throwable)
                 }
             }
         }
@@ -91,7 +91,7 @@ class HistoryViewModel @Inject constructor(
                     }
                 }.onFailure { throwable ->
                     throwable as ThreeDaysException
-                    sendErrorMessage(throwable.message)
+                    sendError(throwable)
                 }
             }
         }

--- a/presentation/history/src/main/java/com/depromeet/threedays/history/detail/DetailHistoryViewModel.kt
+++ b/presentation/history/src/main/java/com/depromeet/threedays/history/detail/DetailHistoryViewModel.kt
@@ -42,7 +42,7 @@ class DetailHistoryViewModel @Inject constructor(
                     )
                 }.onFailure { throwable ->
                     throwable as ThreeDaysException
-                    sendErrorMessage(throwable.message)
+                    sendError(throwable)
                 }
         }
     }
@@ -70,7 +70,7 @@ class DetailHistoryViewModel @Inject constructor(
                 )
             }.onFailure { throwable ->
                 throwable as ThreeDaysException
-                sendErrorMessage(throwable.message)
+                sendError(throwable)
             }
         }
     }

--- a/presentation/home/build.gradle
+++ b/presentation/home/build.gradle
@@ -63,6 +63,8 @@ dependencies {
 
     implementation deps.timber
 
+    implementation deps.sentry
+
     testImplementation(testDeps)
     androidTestImplementation(androidTestDeps)
 }

--- a/presentation/home/src/main/java/com/depromeet/threedays/home/home/HomeViewModel.kt
+++ b/presentation/home/src/main/java/com/depromeet/threedays/home/home/HomeViewModel.kt
@@ -90,7 +90,7 @@ class HomeViewModel @Inject constructor(
                         }
                 }.onFailure { throwable ->
                     throwable as ThreeDaysException
-                    sendErrorMessage(throwable.message)
+                    sendError(throwable)
                 }
             }
         }
@@ -104,7 +104,7 @@ class HomeViewModel @Inject constructor(
                     checkNewClap(habitUI)
                 }.onFailure { throwable ->
                     throwable as ThreeDaysException
-                    sendErrorMessage(throwable.message)
+                    sendError(throwable)
                 }
             }
         }
@@ -120,7 +120,7 @@ class HomeViewModel @Inject constructor(
                     fetchHabits()
                 }.onFailure { throwable ->
                     throwable as ThreeDaysException
-                    sendErrorMessage(throwable.message)
+                    sendError(throwable)
                 }
             }
         }
@@ -187,7 +187,7 @@ class HomeViewModel @Inject constructor(
                     fetchHabits()
                 }.onFailure { throwable ->
                     throwable as ThreeDaysException
-                    sendErrorMessage(throwable.message)
+                    sendError(throwable)
                 }
             }
         }

--- a/presentation/mate/build.gradle
+++ b/presentation/mate/build.gradle
@@ -51,6 +51,8 @@ dependencies {
     implementation deps.hilt.core
     kapt deps.hilt.compiler
 
+    implementation deps.sentry
+
     testImplementation(testDeps)
     androidTestImplementation(androidTestDeps)
 }

--- a/presentation/mate/src/main/java/com/depromeet/threedays/mate/MateViewModel.kt
+++ b/presentation/mate/src/main/java/com/depromeet/threedays/mate/MateViewModel.kt
@@ -95,8 +95,7 @@ class MateViewModel @Inject constructor(
                       }
                 }.onFailure { throwable ->
                     throwable as ThreeDaysException
-
-                    sendErrorMessage(throwable.message)
+                    sendError(throwable)
                 }
             }
 
@@ -117,7 +116,7 @@ class MateViewModel @Inject constructor(
                     }
                 }.onFailure { throwable ->
                     throwable as ThreeDaysException
-                    sendErrorMessage(throwable.message)
+                    sendError(throwable)
                 }
             }
 
@@ -138,7 +137,7 @@ class MateViewModel @Inject constructor(
                     }
                 }.onFailure { throwable ->
                     throwable as ThreeDaysException
-                    sendErrorMessage(throwable.message)
+                    sendError(throwable)
                 }
 
             _uiState.update { it.copy(isHabitInitialized = true) }
@@ -181,7 +180,7 @@ class MateViewModel @Inject constructor(
 //                            value = UiEffect.ShowToastMessage(R.string.delete_mate)
 //                        )
                         throwable as ThreeDaysException
-                        sendErrorMessage(throwable.message)
+                        sendError(throwable)
                     }
                 }
             }

--- a/presentation/mate/src/main/java/com/depromeet/threedays/mate/create/step1/ConnectHabitViewModel.kt
+++ b/presentation/mate/src/main/java/com/depromeet/threedays/mate/create/step1/ConnectHabitViewModel.kt
@@ -39,8 +39,7 @@ class ConnectHabitViewModel @Inject constructor(
                     _habits.value = it.map { habit -> habit.toHabitUI() }
                 }.onFailure { throwable ->
                     throwable as ThreeDaysException
-
-                    sendErrorMessage(throwable.message)
+                    sendError(throwable)
                 }
             }
         }

--- a/presentation/mate/src/main/java/com/depromeet/threedays/mate/create/step3/SetMateNicknameViewModel.kt
+++ b/presentation/mate/src/main/java/com/depromeet/threedays/mate/create/step3/SetMateNicknameViewModel.kt
@@ -90,8 +90,7 @@ class SetMateNicknameViewMoodel @Inject constructor(
                     // TODO
                 }.onFailure { throwable ->
                     throwable as ThreeDaysException
-
-                    sendErrorMessage(throwable.message)
+                    sendError(throwable)
                 }
             }
         }

--- a/presentation/mate/src/main/java/com/depromeet/threedays/mate/share/ShareMateViewModel.kt
+++ b/presentation/mate/src/main/java/com/depromeet/threedays/mate/share/ShareMateViewModel.kt
@@ -5,6 +5,7 @@ import com.depromeet.threedays.core.BaseViewModel
 import com.depromeet.threedays.core_design_system.R
 import com.depromeet.threedays.domain.entity.Color
 import com.depromeet.threedays.domain.entity.habit.SingleHabit
+import com.depromeet.threedays.domain.exception.ThreeDaysException
 import com.depromeet.threedays.domain.repository.HabitRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -34,7 +35,8 @@ class ShareMateViewModel @Inject constructor(
                             )
                         }
                     }.onFailure { throwable ->
-                        sendErrorMessage(throwable.message)
+                        throwable as ThreeDaysException
+                        sendError(throwable)
                     }
             }
         }

--- a/presentation/mypage/build.gradle
+++ b/presentation/mypage/build.gradle
@@ -53,6 +53,8 @@ dependencies {
     implementation deps.hilt.core
     kapt deps.hilt.compiler
 
+    implementation deps.sentry
+
     testImplementation(testDeps)
     androidTestImplementation(androidTestDeps)
 }

--- a/presentation/mypage/src/main/java/com/depromeet/threedays/mypage/MyPageViewModel.kt
+++ b/presentation/mypage/src/main/java/com/depromeet/threedays/mypage/MyPageViewModel.kt
@@ -47,8 +47,7 @@ class MyPageViewModel @Inject constructor(
                     _nickname.value = it.name
                 }.onFailure { throwable ->
                     throwable as ThreeDaysException
-
-                    sendErrorMessage(throwable.message)
+                    sendError(throwable)
                 }
             }
         }
@@ -64,8 +63,7 @@ class MyPageViewModel @Inject constructor(
                     _nickname.value = it.name
                 }.onFailure { throwable ->
                     throwable as ThreeDaysException
-
-                    sendErrorMessage(throwable.message)
+                    sendError(throwable)
                 }
             }
         }
@@ -80,8 +78,10 @@ class MyPageViewModel @Inject constructor(
                 logoutUseCase()
             }.onSuccess {
                 _logoutSucceed.emit(true)
-            }.onFailure {
-                sendErrorMessage(it.message ?: "로그아웃에 실패했습니다. 잠시 후 다시 시도해주세요.")
+            }.onFailure { throwable ->
+                throwable as ThreeDaysException
+                throwable.defaultMessage = ThreeDaysException.LOGOUT_FAIL
+                sendError(throwable)
             }
         }
     }
@@ -95,8 +95,10 @@ class MyPageViewModel @Inject constructor(
                 withdrawUseCase()
             }.onSuccess {
                 _signoutSucceed.emit(true)
-            }.onFailure {
-                sendErrorMessage(it.message ?: "회원탈퇴를 실패했습니다. 잠시 후 다시 시도해주세요.")
+            }.onFailure { throwable ->
+                throwable as ThreeDaysException
+                throwable.defaultMessage = ThreeDaysException.MEMBERSHIP_WITHDRAWAL_FAIL
+                sendError(throwable)
             }
         }
     }

--- a/presentation/mypage/src/main/java/com/depromeet/threedays/mypage/archived_habit/ArchivedHabitViewModel.kt
+++ b/presentation/mypage/src/main/java/com/depromeet/threedays/mypage/archived_habit/ArchivedHabitViewModel.kt
@@ -50,8 +50,7 @@ class ArchivedHabitViewModel @Inject constructor(
                     }
                 }.onFailure { throwable ->
                     throwable as ThreeDaysException
-
-                    sendErrorMessage(throwable.message)
+                    sendError(throwable)
                 }
             }
         }

--- a/presentation/notification/build.gradle
+++ b/presentation/notification/build.gradle
@@ -50,6 +50,8 @@ dependencies {
     implementation deps.hilt.core
     kapt deps.hilt.compiler
 
+    implementation deps.sentry
+
     testImplementation(testDeps)
     androidTestImplementation(androidTestDeps)
 }

--- a/presentation/notification/src/main/java/com/depromeet/threedays/notification/NotificationHistoryViewModel.kt
+++ b/presentation/notification/src/main/java/com/depromeet/threedays/notification/NotificationHistoryViewModel.kt
@@ -32,8 +32,7 @@ class NotificationHistoryViewModel @Inject constructor(
                     _notifications.value = notifications.map { NotificationHistoryUI.from(it) }
                 }.onFailure { throwable ->
                     throwable as ThreeDaysException
-
-                    sendErrorMessage(throwable.message)
+                    sendError(throwable)
                 }
             }
         }
@@ -57,8 +56,7 @@ class NotificationHistoryViewModel @Inject constructor(
                     }
                 }.onFailure { throwable ->
                     throwable as ThreeDaysException
-
-                    sendErrorMessage(throwable.message)
+                    sendError(throwable)
                 }
             }
         }

--- a/presentation/signup/build.gradle
+++ b/presentation/signup/build.gradle
@@ -55,6 +55,8 @@ dependencies {
 
     implementation deps.login.kakao
 
+    implementation deps.sentry
+
     testImplementation(testDeps)
     androidTestImplementation(androidTestDeps)
 }

--- a/presentation/signup/src/main/java/com/depromeet/threedays/signup/SignupViewModel.kt
+++ b/presentation/signup/src/main/java/com/depromeet/threedays/signup/SignupViewModel.kt
@@ -37,12 +37,14 @@ class SignupViewModel @Inject constructor(
                     Timber.i("--- SignupViewModel - token : ${value.token}")
                 }.onFailure { throwable ->
                     throwable as ThreeDaysException
-                    sendErrorMessage(throwable.message)
+                    throwable.defaultMessage = ThreeDaysException.LOGIN_FAIL
+                    sendError(throwable)
                     Timber.e("--- SignupViewModel - Signup error: ${throwable.message}")
                 }
             }.onFailure { throwable ->
                 throwable as ThreeDaysException
-                sendErrorMessage(throwable.message)
+                throwable.defaultMessage = ThreeDaysException.LOGIN_FAIL
+                sendError(throwable)
                 Timber.e("--- SignupViewModel - Signup error: ${throwable.message}")
             }
         }


### PR DESCRIPTION
## 💁‍♂️ 변경 내용
### AS-IS
- 에러 발생 시 토스트로만 유저에게 알려주었고, 개발자는 crash가 아닌 애러는 리포트받을 수 없었습니다.

### TO-BE
- relaese/degub 별로 에러 발생 시 sentry를 통해 해당 에러를 추적할 수 있습니다.
- 인터넷 연결 오류 시엔 sentry로 에러를 보고하지 않습니다.

## 📢 전달사항
- 인터넷 연결 오류 시엔 sentry로 에러를 안보내게 하려고 했는데, 이 로직을 하나의 함수로 만들어서 하려니까 sentry에 리포트 되는 위치가 A activity 가 아닌 해당 함수가 선언된.. 가령 SentrySdk class 등으로 위치가 표시되어서 .. 다 일일히 작성했는데 더 좋은 의견 있으실까요??

Sentry three-days-dev : https://depromeet-d5233f6c0.sentry.io/issues/?referrer=sidebar

디프만 공용계정으로 로그인하시면 됩니다!

**local property** 설정하셔야 하는데 이건 따로 올려두겠습니다!